### PR TITLE
refactor history data to include passing test data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,10 @@ GIT
 PATH
   remote: /Users/elr37/Documents/__DEVELOPMENT__/LD4L/_LD4L3/sprint/LD4P/qa_server
   specs:
-    qa_server (0.1.99)
+    qa_server (1.0.0)
+      chartkick
+      linkeddata
+      qa
       rails (= 5.1.6)
 
 GEM
@@ -82,6 +85,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    chartkick (3.0.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,7 @@ PATH
   remote: /Users/elr37/Documents/__DEVELOPMENT__/LD4L/_LD4L3/sprint/LD4P/qa_server
   specs:
     qa_server (1.0.0)
-      chartkick
-      linkeddata
-      qa
+      gruff
       rails (= 5.1.6)
 
 GEM
@@ -73,6 +71,8 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
       rubocop-rspec (~> 1.22, <= 1.22.2)
@@ -85,7 +85,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    chartkick (3.0.1)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -99,6 +98,7 @@ GEM
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.3)
@@ -112,11 +112,13 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.7.1)
     execjs (2.7.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    gruff (0.7.0)
+      rmagick (~> 2.13, >= 2.13.4)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
@@ -279,6 +281,7 @@ GEM
       rdf (~> 3.0)
     rdf-xsd (3.0.0)
       rdf (~> 3.0)
+    rmagick (2.16.0)
     rspec-activemodel-mocks (1.0.3)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -315,7 +318,7 @@ GEM
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
-    sass (3.5.7)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -367,7 +370,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.18)
+    uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.0)
     web-console (3.7.0)
@@ -386,6 +389,7 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors
+  binding_of_caller
   bixby (~> 1.0.0)
   byebug
   capybara (~> 2.13)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Tested with...
 * Ruby 2.4.3
 * Rails 5.1.6
 
+### Prerequisites
+
+1. [ImageMagick](http://www.imagemagick.org/)
+
 ### Installation Instructions
 
 #### Adding the engine dependency

--- a/app/controllers/qa_server/authority_validation_controller.rb
+++ b/app/controllers/qa_server/authority_validation_controller.rb
@@ -3,8 +3,6 @@ module QaServer
   class AuthorityValidationController < ApplicationController
     layout 'qa_server'
 
-    attr_reader :status_data
-
     class_attribute :validator_class,
                     :lister_class,
                     :logger_class

--- a/app/loggers/qa_server/scenario_logger.rb
+++ b/app/loggers/qa_server/scenario_logger.rb
@@ -27,11 +27,13 @@ module QaServer
     # @option expected [Integer] the expected result (e.g. min size of result OR max position of subject within results)
     # @option actual [Integer] the actual result (e.g. actual size of results OR actual position of subject within results)
     # @option target [String] the expected target that was validated (e.g. subject_uri for query, pref label for term fetch)
-    def add(status_info) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # @option request_run_time [BigDecimal] the amount of time to retrieve data from the authority
+    # @option normalization_run_time [BigDecimal] the amount of time to normalize the retrieved data into json
+    def add(status_info) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
       @test_count += 1
+      @failure_count += 1 unless status_info[:status] == PASS
       @log << { type: status_info[:validation_type] || '',
                 status: status_info[:status] || '',
-                status_label: status_label(status_info[:status]),
                 authority_name: status_info[:authority_name] || '',
                 subauthority_name: status_info[:subauth] || '',
                 service: status_info[:service] || '',
@@ -40,7 +42,9 @@ module QaServer
                 expected: status_info[:expected] || nil,
                 actual: status_info[:actual] || nil,
                 target: status_info[:target] || nil,
-                err_message: status_info[:error_message] || '' }
+                err_message: status_info[:error_message] || '',
+                request_run_time: status_info[:request_run_time] || nil,
+                normalization_run_time: status_info[:normalization_run_time] || nil }
     end
 
     # Delete from the log any tests that passed.

--- a/app/loggers/qa_server/scenario_logger.rb
+++ b/app/loggers/qa_server/scenario_logger.rb
@@ -2,6 +2,11 @@
 # Provide a log of scenario data and test results
 module QaServer
   class ScenarioLogger
+    include Enumerable
+
+    # @return the number of scenarios recorded in the log
+    delegate :size, :each, to: :@log
+
     attr_reader :test_count, :failure_count
 
     PASS = QaServer::ScenarioValidator::PASS
@@ -71,27 +76,5 @@ module QaServer
     def to_a
       @log
     end
-
-    # @return the number of scenarios recorded in the log
-    def size
-      @log.size
-    end
-
-    private
-
-      def status_label(status)
-        case status
-        when PASS
-          '√'
-        when UNKNOWN
-          @failure_count += 1
-          '?'
-        when FAIL
-          @failure_count += 1
-          'X'
-        else
-          ''
-        end
-      end
   end
 end

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Provide access to the scenario_results_history database table which tracks specific scenario runs over time.
 module QaServer
   class ScenarioRunHistory < ActiveRecord::Base
@@ -6,9 +7,9 @@ module QaServer
     enum scenario_type: [:connection, :accuracy, :performance], _suffix: :type
     enum status: [:good, :bad, :unknown], _suffix: true
 
-    GOOD_MARKER = '√'.freeze
-    BAD_MARKER = 'X'.freeze
-    UNKNOWN_MARKER = '?'.freeze
+    GOOD_MARKER = '√'
+    BAD_MARKER = 'X'
+    UNKNOWN_MARKER = '?'
 
     class_attribute :summary_class
 

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -1,0 +1,182 @@
+# Provide access to the scenario_results_history database table which tracks specific scenario runs over time.
+module QaServer
+  class ScenarioRunHistory < ActiveRecord::Base
+    self.table_name = 'scenario_run_history'
+    belongs_to :scenario_run_registry
+    enum scenario_type: [:connection, :accuracy, :performance], _suffix: :type
+    enum status: [:good, :bad, :unknown], _suffix: true
+
+    GOOD_MARKER = '√'.freeze
+    BAD_MARKER = 'X'.freeze
+    UNKNOWN_MARKER = '?'.freeze
+
+    class_attribute :summary_class
+
+    self.summary_class = QaServer::ScenarioRunSummary
+
+    # Save a scenario result
+    # @param run_id [Integer] the run on which to gather statistics
+    # @param result [Hash] the scenario result to be saved
+    def self.save_result(run_id:, scenario_result:)
+      QaServer::ScenarioRunHistory.create(scenario_run_registry_id: run_id,
+                                          status: scenario_result[:status],
+                                          authority_name: scenario_result[:authority_name],
+                                          subauthority_name: scenario_result[:subauthority_name],
+                                          service: scenario_result[:service],
+                                          action: scenario_result[:action],
+                                          url: scenario_result[:url],
+                                          err_message: scenario_result[:err_message],
+                                          run_time: scenario_result[:run_time])
+    end
+
+    # Get a summary of passing/failing tests for a run.
+    # @param scenario_run [ScenarioRunRegistry] the run on which to gather statistics
+    # @returns [Hash] statistics on the requested run
+    # @example
+    #   { run_id: 14,
+    #     failing_count: 3,
+    #     passing_count: 156,
+    #     total_count: 159,
+    #     authority_count: 22,
+    #     failing_authority_count: 1 }
+    def self.run_summary(scenario_run:)
+      return nil unless scenario_run && scenario_run.id
+      status = status_counts_in_run(run_id: scenario_run.id)
+      summary_class.new(run_id: scenario_run.id,
+                        run_dt_stamp: scenario_run.dt_stamp,
+                        authority_count: authorities_in_run(run_id: scenario_run.id).count,
+                        failing_authority_count: authorities_with_failures_in_run(run_id: scenario_run.id).count,
+                        passing_scenario_count: status['good'],
+                        failing_scenario_count: status['bad'] + status['unknown'])
+    end
+
+    # Get set of all scenario results for a run.
+    # @param run_id [Integer] the run on which to gather statistics
+    # @param authority_name [String] limit results to those for the authority with this name
+    # @param status [Array<Symbol> | Symbol] :good, :bad, :unknown, or any of these in an array to select multiple status
+    # @param url [String] limit results to a specific scenario URL
+    # @returns [Array<ScenarioRunHistory>] scenario details for all scenarios in the run
+    # @example
+    #   [ { status: :bad,
+    #       authority_name: "geonames_ld4l_cache",
+    #       subauthority_name: "area",
+    #       service: "ld4l_cache",
+    #       action: "search",
+    #       url: "/qa/search/linked_data/geonames_ld4l_cache/area?q=France&maxRecords=4",
+    #       err_message: "Unable to connect to authority",
+    #       scenario_type: :connection
+    #       run_time: 11.2 },
+    #     { status: :good,
+    #       authority_name: "oclcfast_ld4l_cache",
+    #       subauthority_name: "Organization",
+    #       service: "ld4l_cache",
+    #       action: "search",
+    #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/organization?q=mark twain&maxRecords=4",
+    #       err_message: "",
+    #       scenario_type: :connection
+    #       run_time: 0.131 },
+    #     { status: :unknown,
+    #       authority_name: "oclcfast_ld4l_cache",
+    #       subauthority_name: "Person",
+    #       service: "ld4l_cache",
+    #       action: "search",
+    #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/person?q=mark twain&maxRecords=4",
+    #       err_message: "Not enough search results returned",
+    #       scenario_type: :connection
+    #       run_time: 0.123 } ]
+    def self.run_results(run_id:, authority_name: nil, status: nil, url: nil)
+      return [] unless run_id
+      where = {}
+      where[:scenario_run_registry_id] = run_id
+      where[:authority_name] = authority_name if authority_name.present?
+      where[:status] = status if status.present?
+      where[:url] = url if url.present?
+      QaServer::ScenarioRunHistory.where(where).to_a
+    end
+
+    # Get set of failures for a run, if any.
+    # @param run_id [Integer] the run on which to gather statistics
+    # @returns [Array<Hash>] scenario details for any failing scenarios in the run
+    # @example
+    #   [ { status: :bad,
+    #       authority_name: "geonames_ld4l_cache",
+    #       subauthority_name: "area",
+    #       service: "ld4l_cache",
+    #       action: "search",
+    #       url: "/qa/search/linked_data/geonames_ld4l_cache/area?q=France&maxRecords=4",
+    #       err_message: "Unable to connect to authority",
+    #       scenario_type: :connection
+    #       run_time: 11.2 },
+    #     { status: :unknown,
+    #       authority_name: "oclcfast_ld4l_cache",
+    #       subauthority_name: "Person",
+    #       service: "ld4l_cache",
+    #       action: "search",
+    #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/person?q=mark twain&maxRecords=4",
+    #       err_message: "Not enough search results returned",
+    #       scenario_type: :connection
+    #       run_time: 0.123 } ]
+    def self.run_failures(run_id:)
+      return [] unless run_id
+      QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: :good).to_a
+    end
+
+    # Get a summary level of historical data
+    # @returns [Array<Hash>] scenario details for any failing scenarios in the run
+    # @example
+    #   [ [ 'agrovoc', 24, 0 ],
+    #     [ 'geonames_ld4l_cache', 24, 2 ] ... ]
+    def self.historical_summary
+      runs = all_runs_per_authority
+      failures = failing_runs_per_authority
+      return [] unless runs.present?
+      data = []
+      runs.each do |auth_name, run_count|
+        auth_data = []
+        auth_data[0] = auth_name
+        failure_count = (failures.key? auth_name) ? failures[auth_name] : 0
+        auth_data[1] = failure_count
+        auth_data[2] = run_count - failure_count # passing
+        data << auth_data
+      end
+      data
+    end
+
+    private
+      def self.authorities_in_run(run_id:)
+        QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).pluck(:authority_name).uniq
+      end
+
+      def self.authorities_with_failures_in_run(run_id:)
+        QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: 'good').pluck('authority_name').uniq
+      end
+
+      def self.status_counts_in_run(run_id:)
+        status = QaServer::ScenarioRunHistory.group('status').where(scenario_run_registry_id: run_id).count
+        status["good"] = 0 unless status.key? "good"
+        status["bad"] = 0 unless status.key? "bad"
+        status["unknown"] = 0 unless status.key? "unknown"
+        status
+      end
+
+      def self.all_runs_per_authority
+        authority_runs = QaServer::ScenarioRunHistory.pluck(:authority_name, :scenario_run_registry_id).uniq
+        runs_per_authority(authority_runs)
+      end
+
+      def self.failing_runs_per_authority
+        failing_authority_runs = QaServer::ScenarioRunHistory.where.not(status: 'good').pluck(:authority_name, :scenario_run_registry_id).uniq
+        runs_per_authority(failing_authority_runs)
+      end
+
+      def self.runs_per_authority(authority_runs)
+        runs_per_authority = {}
+        authority_runs.each do |auth_run|
+          auth_name = auth_run[0]
+          runs_per_authority[auth_name] = 0 unless runs_per_authority.key? auth_name
+          runs_per_authority[auth_name] += 1
+        end
+        runs_per_authority
+      end
+  end
+end

--- a/app/models/qa_server/scenario_run_registry.rb
+++ b/app/models/qa_server/scenario_run_registry.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Provide access to the scenario_run_registry database table which registers each run of tests made over time.
 module QaServer
   class ScenarioRunRegistry < ActiveRecord::Base
@@ -25,10 +26,9 @@ module QaServer
       scenarios_results.each { |result| QaServer::ScenarioRunHistory.save_result(run_id: run.id, scenario_result: result) }
     end
 
-    private
-
-      def self.dt_stamp_now_et
-        Time.now.in_time_zone("Eastern Time (US & Canada)")
-      end
+    def self.dt_stamp_now_et
+      Time.now.in_time_zone("Eastern Time (US & Canada)")
+    end
+    private_class_method :dt_stamp_now_et
   end
 end

--- a/app/models/qa_server/scenario_run_registry.rb
+++ b/app/models/qa_server/scenario_run_registry.rb
@@ -1,0 +1,34 @@
+# Provide access to the scenario_run_registry database table which registers each run of tests made over time.
+module QaServer
+  class ScenarioRunRegistry < ActiveRecord::Base
+    self.table_name = 'scenario_run_registry'
+    has_many :scenario_run_history, foreign_key: :scenario_run_registry_id
+
+    # Get the latest saved run of scenarios.
+    def self.latest_run
+      return nil unless QaServer::ScenarioRunRegistry.last
+      QaServer::ScenarioRunRegistry.last # Can we count on last to always be the one with the latest dt_stamp?
+      # latest_run = ScenarioRunRegistry.all.sort(:dt_stamp).last
+      # return nil if latest_run.blank?
+      # latest_run.id
+    end
+
+    # Get the latest saved status.
+    def self.latest_run_id
+      latest = latest_run
+      return nil unless latest
+      lastest.id
+    end
+
+    def self.save_run(scenarios_results:)
+      run = QaServer::ScenarioRunRegistry.create(dt_stamp: dt_stamp_now_et)
+      scenarios_results.each { |result| QaServer::ScenarioRunHistory.save_result(run_id: run.id, scenario_result: result) }
+    end
+
+    private
+
+      def self.dt_stamp_now_et
+        Time.now.in_time_zone("Eastern Time (US & Canada)")
+      end
+  end
+end

--- a/app/models/qa_server/scenario_run_summary.rb
+++ b/app/models/qa_server/scenario_run_summary.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
 # Abstract class that parses the authority configuration from the yml file into the parts needed by inheriting scenario types.
 module QaServer
   class ScenarioRunSummary
-
     # @return [Integer] the id of the scenario run being summarized
     attr_reader :run_id
 
@@ -29,6 +29,7 @@ module QaServer
     # @param failing_authority_count [Integer] number of authorities in the run that had failing tests
     # @param passing_scenario_count [Integer] number of scenarios that passed during this run
     # @param failing_scenario_count [Integer] number of scenarios that failed during this run
+    # rubocop:disable Metrics/ParameterLists
     def initialize(run_id:, run_dt_stamp:, authority_count:, failing_authority_count:, passing_scenario_count:, failing_scenario_count:)
       @run_id = run_id
       @run_dt_stamp = run_dt_stamp
@@ -38,5 +39,6 @@ module QaServer
       @failing_scenario_count = failing_scenario_count
       @total_scenario_count = failing_scenario_count + passing_scenario_count
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/app/models/qa_server/scenario_run_summary.rb
+++ b/app/models/qa_server/scenario_run_summary.rb
@@ -1,0 +1,42 @@
+# Abstract class that parses the authority configuration from the yml file into the parts needed by inheriting scenario types.
+module QaServer
+  class ScenarioRunSummary
+
+    # @return [Integer] the id of the scenario run being summarized
+    attr_reader :run_id
+
+    # @return [Date] the date time stamp of the scenario run being summarized
+    attr_reader :run_dt_stamp
+
+    # @return [Integer] number of all authorities in the run
+    attr_reader :authority_count
+
+    # @return [Integer] number of authorities in the run that had at least one failing test
+    attr_reader :failing_authority_count
+
+    # @return [Integer] number of scenarios that passed during this run
+    attr_reader :passing_scenario_count
+
+    # @return [Integer] name of the subauthority the scenario runs against
+    attr_reader :failing_scenario_count
+
+    # @return [Integer] total number of scenarios in this run
+    attr_reader :total_scenario_count
+
+    # @param run_id [Integer] the id of the scenario run being summarized
+    # @param run_dt_stamp [Date] the date time stamp of the scenario run being summarized
+    # @param authority_count [Integer] number of all authorities in the run
+    # @param failing_authority_count [Integer] number of authorities in the run that had failing tests
+    # @param passing_scenario_count [Integer] number of scenarios that passed during this run
+    # @param failing_scenario_count [Integer] number of scenarios that failed during this run
+    def initialize(run_id:, run_dt_stamp:, authority_count:, failing_authority_count:, passing_scenario_count:, failing_scenario_count:)
+      @run_id = run_id
+      @run_dt_stamp = run_dt_stamp
+      @authority_count = authority_count
+      @failing_authority_count = failing_authority_count
+      @passing_scenario_count = passing_scenario_count
+      @failing_scenario_count = failing_scenario_count
+      @total_scenario_count = failing_scenario_count + passing_scenario_count
+    end
+  end
+end

--- a/app/presenters/qa_server/check_status_presenter.rb
+++ b/app/presenters/qa_server/check_status_presenter.rb
@@ -59,17 +59,17 @@ module QaServer
       "status-#{status[:status]}"
     end
 
-  # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
-  def status_label(status)
-    case status[:status]
-    when :good
-      QaServer::ScenarioRunHistory::GOOD_MARKER
-    when :bad
-      QaServer::ScenarioRunHistory::BAD_MARKER
-    when :unknown
-      QaServer::ScenarioRunHistory::UNKNOWN_MARKER
+    # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
+    def status_label(status)
+      case status[:status]
+      when :good
+        QaServer::ScenarioRunHistory::GOOD_MARKER
+      when :bad
+        QaServer::ScenarioRunHistory::BAD_MARKER
+      when :unknown
+        QaServer::ScenarioRunHistory::UNKNOWN_MARKER
+      end
     end
-  end
 
     def value_all_collections
       QaServer::CheckStatusController::ALL_AUTHORITIES

--- a/app/presenters/qa_server/check_status_presenter.rb
+++ b/app/presenters/qa_server/check_status_presenter.rb
@@ -59,6 +59,18 @@ module QaServer
       "status-#{status[:status]}"
     end
 
+  # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
+  def status_label(status)
+    case status[:status]
+    when :good
+      QaServer::ScenarioRunHistory::GOOD_MARKER
+    when :bad
+      QaServer::ScenarioRunHistory::BAD_MARKER
+    when :unknown
+      QaServer::ScenarioRunHistory::UNKNOWN_MARKER
+    end
+  end
+
     def value_all_collections
       QaServer::CheckStatusController::ALL_AUTHORITIES
     end

--- a/app/presenters/qa_server/monitor_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status_presenter.rb
@@ -81,7 +81,7 @@ module QaServer
     #   [ [ 'agrovoc', 24, 0 ],
     #     [ 'geonames_ld4l_cache', 24, 2 ] ... ]
     def historical_summary
-     @historical_summary_data
+      @historical_summary_data
     end
 
     # @return [Boolean] true if historical test data exists; otherwise false
@@ -92,18 +92,18 @@ module QaServer
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
     def status_style_class(status)
-      "status-#{status[:status].to_s}"
+      "status-#{status[:status]}"
     end
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
     def status_label(status)
       case status[:status]
-        when :good
-          QaServer::ScenarioRunHistory::GOOD_MARKER
-        when :bad
-          QaServer::ScenarioRunHistory::BAD_MARKER
-        when :unknown
-          QaServer::ScenarioRunHistory::UNKNOWN_MARKER
+      when :good
+        QaServer::ScenarioRunHistory::GOOD_MARKER
+      when :bad
+        QaServer::ScenarioRunHistory::BAD_MARKER
+      when :unknown
+        QaServer::ScenarioRunHistory::UNKNOWN_MARKER
       end
     end
   end

--- a/app/validators/qa_server/scenario_validator.rb
+++ b/app/validators/qa_server/scenario_validator.rb
@@ -36,20 +36,16 @@ module QaServer
     private
 
       # Log the structure of the scenario and status of a test run.
-      def log(status: nil, errmsg: nil, expected: nil, actual: nil, target: nil, request_run_time: nil, normalization_run_time: nil)
-        status_log.add(authority_name: authority_name,
-                       status: status,
-                       validation_type: scenario_validation_type,
-                       subauth: subauthority_name,
-                       service: service,
-                       action: action,
-                       url: url,
-                       error_message: errmsg,
-                       expected: expected,
-                       actual: actual,
-                       target: target,
-                       request_run_time: request_run_time,
-                       normalization_run_time: normalization_run_time)
+      # @param [Hash] status_info holding information to be logged
+      # @see QaServer::ScenarioLogger
+      def log(status_info = {})
+        status_info[:authority_name] = authority_name
+        status_info[:validation_type] = scenario_validation_type
+        status_info[:subauth] = subauthority_name
+        status_info[:service] = service
+        status_info[:action] = action
+        status_info[:url] = url
+        status_log.add(status_info)
       end
 
       def run_accuracy_scenario

--- a/app/validators/qa_server/scenario_validator.rb
+++ b/app/validators/qa_server/scenario_validator.rb
@@ -62,18 +62,18 @@ module QaServer
 
       # Runs the test in the block passed by the specific scenario type.
       # @return [Symbol] :good (PASS) or :unknown (UNKNOWN) based on whether enough results were returned
-    def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
-      dt_start = Time.now.utc
-      results = yield if block_given?
-      dt_end = Time.now.utc
-      actual_size = results.to_s.length
-      status = actual_size > min_expected_size ? PASS : UNKNOWN
-      errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
-      log(status: status, errmsg: errmsg, normalization_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
-    rescue Exception => e
-      dt_end = Time.now.utc
-      log(status: FAIL, errmsg: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
-    end
+      def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
+        dt_start = Time.now.utc
+        results = yield if block_given?
+        dt_end = Time.now.utc
+        actual_size = results.to_s.length
+        status = actual_size > min_expected_size ? PASS : UNKNOWN
+        errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
+        log(status: status, errmsg: errmsg, normalization_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
+      rescue Exception => e
+        dt_end = Time.now.utc
+        log(status: FAIL, errmsg: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
+      end
 
       def authority
         scenario.authority

--- a/app/validators/qa_server/scenario_validator.rb
+++ b/app/validators/qa_server/scenario_validator.rb
@@ -36,7 +36,7 @@ module QaServer
     private
 
       # Log the structure of the scenario and status of a test run.
-      def log(status: nil, errmsg: nil, expected: nil, actual: nil, target: nil)
+      def log(status: nil, errmsg: nil, expected: nil, actual: nil, target: nil, request_run_time: nil, normalization_run_time: nil)
         status_log.add(authority_name: authority_name,
                        status: status,
                        validation_type: scenario_validation_type,
@@ -47,7 +47,9 @@ module QaServer
                        error_message: errmsg,
                        expected: expected,
                        actual: actual,
-                       target: target)
+                       target: target,
+                       request_run_time: request_run_time,
+                       normalization_run_time: normalization_run_time)
       end
 
       def run_accuracy_scenario
@@ -60,15 +62,18 @@ module QaServer
 
       # Runs the test in the block passed by the specific scenario type.
       # @return [Symbol] :good (PASS) or :unknown (UNKNOWN) based on whether enough results were returned
-      def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
-        results = yield if block_given?
-        actual_size = results.to_s.length
-        status = actual_size > min_expected_size ? PASS : UNKNOWN
-        errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
-        log(status: status, errmsg: errmsg)
-      rescue Exception => e
-        log(status: FAIL, errmsg: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}")
-      end
+    def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
+      dt_start = Time.now.utc
+      results = yield if block_given?
+      dt_end = Time.now.utc
+      actual_size = results.to_s.length
+      status = actual_size > min_expected_size ? PASS : UNKNOWN
+      errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
+      log(status: status, errmsg: errmsg, normalization_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
+    rescue Exception => e
+      dt_end = Time.now.utc
+      log(status: FAIL, errmsg: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
+    end
 
       def authority
         scenario.authority
@@ -111,12 +116,12 @@ module QaServer
       end
 
       def accuracy_scenario?
-        # ABSTRACT define in specific scenario type validator (i.e. TermScenarioValidator, SearchScenarioValidator)
+        # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
         false
       end
 
       def connection_scenario?
-        # ABSTRACT define in specific scenario type validator (i.e. TermScenarioValidator, SearchScenarioValidator)
+        # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
         false
       end
   end

--- a/app/validators/qa_server/search_scenario_validator.rb
+++ b/app/validators/qa_server/search_scenario_validator.rb
@@ -70,9 +70,12 @@ module QaServer
 
         actual_position += 1
         if actual_position <= expected_by_position
-          log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri, normalization_run_time: run_time) # TODO: need to get run times from results
+          log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri,
+              normalization_run_time: run_time) # TODO: need to get run times from results
         else
-          log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.', expected: expected_by_position, actual: actual_position, target: subject_uri, normalization_run_time: total_run_time) # TODO: need to get run times from results
+          log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.',
+              expected: expected_by_position, actual: actual_position, target: subject_uri,
+              normalization_run_time: total_run_time) # TODO: need to get run times from results
         end
       end
 

--- a/app/validators/qa_server/search_scenario_validator.rb
+++ b/app/validators/qa_server/search_scenario_validator.rb
@@ -39,15 +39,19 @@ module QaServer
 
       # Runs the accuracy test and log results
       def test_accuracy(subject_uri:, expected_by_position:)
+        dt_start = Time.now.utc
         results = yield if block_given?
+        dt_end = Time.now.utc
         if results.blank?
-          log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: no results found", expected: expected_by_position, target: subject_uri)
+          log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: no results found", expected: expected_by_position, target: subject_uri, request_run_time: (dt_end - dt_start))
           return
         end
 
-        check_position(results, subject_uri, expected_by_position)
+        check_position(results, subject_uri, expected_by_position, total_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
       rescue Exception => e
-        log(status: FAIL, errmsg: "Exception executing search position scenario; cause: #{e.message}", expected: expected_by_position, target: subject_uri)
+        dt_end = Time.now.utc
+        log(status: FAIL, errmsg: "Exception executing search position scenario; cause: #{e.message}",
+            expected: expected_by_position, target: subject_uri, request_run_time: (dt_end - dt_start))
       end
 
       def accuracy_scenario?
@@ -60,23 +64,24 @@ module QaServer
         !accuracy_scenario?
       end
 
-      def check_position(results, subject_uri, expected_by_position)
-        actual_position = subject_position(results, subject_uri)
+      def check_position(results, subject_uri, expected_by_position, total_run_time)
+        actual_position = subject_position(results, subject_uri, total_run_time)
         return if actual_position.blank?
 
         actual_position += 1
         if actual_position <= expected_by_position
-          log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri)
+          log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri, normalization_run_time: run_time) # TODO: need to get run times from results
         else
-          log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.', expected: expected_by_position, actual: actual_position, target: subject_uri)
+          log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.', expected: expected_by_position, actual: actual_position, target: subject_uri, normalization_run_time: total_run_time) # TODO: need to get run times from results
         end
       end
 
-      def subject_position(results, subject_uri)
+      def subject_position(results, subject_uri, total_run_time)
         0.upto(results.size - 1) do |position|
           return position if results[position][:uri] == subject_uri
         end
-        log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: subject uri (#{subject_uri}) not found in results", expected: scenario.expected_by_position, target: subject_uri)
+        log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: subject uri (#{subject_uri}) not found in results",
+            expected: scenario.expected_by_position, target: subject_uri, normalization_run_time: total_run_time) # TODO: need to get run times from results
         nil
       end
   end

--- a/app/views/qa_server/check_status/index.html.erb
+++ b/app/views/qa_server/check_status/index.html.erb
@@ -56,7 +56,7 @@
     </tr>
     <% @presenter.connection_status_data.each do |status| %>
     <tr>
-      <td class="<%= @presenter.status_style_class(status) %>"><%= status[:status_label] %></td>
+      <td class="<%= @presenter.status_style_class(status) %>"><%= @presenter.status_label(status) %></td>
       <td><%= status[:authority_name] %></td>
       <td><%= status[:subauthority_name] %></td>
       <td><%= status[:service] %></td>

--- a/app/views/qa_server/monitor_status/index.html.erb
+++ b/app/views/qa_server/monitor_status/index.html.erb
@@ -54,9 +54,9 @@
   <% if @presenter.history? %>
       <div id="status-section" class="status-section">
         <h2><%= t('qa_server.monitor_status.history.title') %></h2>
-
-        <p class="status-update-dtstamp"><%= t('monitor_status.history.since', date: @presenter.first_updated) %></p>
+        <p class="status-update-dtstamp"><%= t('qa_server.monitor_status.history.since', date: @presenter.first_updated) %></p>
         <%#= column_chart @presenter.historical_summary, stacked: true, colors: ["green", "red"], xtitle: 'Authority', ytitle: 'Pass-Fail', legend: 'bottom' %>
+        <%= image_tag(@presenter.historical_graph, alt: 'History Graph Unavailable') %>
 
 <!--
         <table class="status">

--- a/app/views/qa_server/monitor_status/index.html.erb
+++ b/app/views/qa_server/monitor_status/index.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
+
 <div class="page-description">
   <h2><%= t('qa_server.monitor_status.summary.title') %></h2>
 
@@ -36,7 +38,7 @@
         </tr>
         <% @status_data.each do |status| %>
             <tr>
-              <td class="<%= "status-#{status[:status].to_s}" %>"><%= status[:status_label] %></td>
+              <td class="<%= @presenter.status_style_class(status) %>"><%= @presenter.status_label(status) %></td>
               <td><%= status[:authority_name] %></td>
               <td><%= status[:subauthority_name] %></td>
               <td><%= status[:service] %></td>
@@ -53,8 +55,10 @@
       <div id="status-section" class="status-section">
         <h2><%= t('qa_server.monitor_status.history.title') %></h2>
 
-        <h3><%= t('qa_server.monitor_status.history.since', date: @presenter.first_updated) %></h3>
+        <p class="status-update-dtstamp"><%= t('monitor_status.history.since', date: @presenter.first_updated) %></p>
+        <%#= column_chart @presenter.historical_summary, stacked: true, colors: ["green", "red"], xtitle: 'Authority', ytitle: 'Pass-Fail', legend: 'bottom' %>
 
+<!--
         <table class="status">
           <tr>
             <th><%= t('qa_server.monitor_status.history.days_failing') %></th>
@@ -63,16 +67,17 @@
             <th><%= t('qa_server.monitor_status.history.service') %></th>
             <th><%= t('qa_server.monitor_status.history.action') %></th>
           </tr>
-          <% @presenter.history.each do |entry| %>
+          <%# @presenter.history.each do |entry| %>
               <tr>
-                <td><%= entry[:days_failing] %></td>
-                <td><%= entry[:authority_name] %></td>
-                <td><%= entry[:subauthority_name] %></td>
-                <td><%= entry[:service] %></td>
-                <td><%= entry[:action] %></td>
+                <td><%#= entry[:days_failing] %></td>
+                <td><%#= entry[:authority_name] %></td>
+                <td><%#= entry[:subauthority_name] %></td>
+                <td><%#= entry[:service] %></td>
+                <td><%#= entry[:action] %></td>
               </tr>
-          <% end %>
+          <%# end %>
         </table>
+-->
       </div>
   <% end %>
 </div>

--- a/lib/generators/qa_server/templates/db/migrate/20180807045549_create_scenario_run_registry.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20180807045549_create_scenario_run_registry.rb.erb
@@ -1,0 +1,7 @@
+class CreateScenarioRunRegistry < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :scenario_run_registry do |t|
+      t.datetime :dt_stamp
+    end
+  end
+end

--- a/lib/generators/qa_server/templates/db/migrate/20180807045552_create_scenario_run_history.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20180807045552_create_scenario_run_history.rb.erb
@@ -1,0 +1,16 @@
+class CreateScenarioRunHistory < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :scenario_run_history do |t|
+      t.belongs_to :scenario_run_registry
+      t.integer :status, default: 2 # :good, :bad, :unknown
+      t.string :authority_name
+      t.string :subauthority_name
+      t.string :service
+      t.string :action
+      t.string :url
+      t.string :err_message
+      t.integer :scenario_type, default: 0 # :connection, :accuracy, :performance
+      t.decimal :run_time, precision: 10, scale: 4
+    end
+  end
+end

--- a/lib/generators/qa_server/templates/db/migrate/20180807045554_drop_unused_tables.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20180807045554_drop_unused_tables.rb.erb
@@ -1,0 +1,6 @@
+class DropUnusedTables < ActiveRecord::Migration<%= migration_version %>
+  def change
+    drop_table :authority_status_failure
+    drop_table :authority_status
+  end
+end

--- a/lib/generators/qa_server/templates/db/migrate/20180809045552_add_indices_to_scenario_run_history.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20180809045552_add_indices_to_scenario_run_history.rb.erb
@@ -1,0 +1,8 @@
+class AddIndicesToScenarioRunHistory < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_index :scenario_run_history, :url
+    add_index :scenario_run_history, :status
+    add_index :scenario_run_history, :authority_name
+    add_index :scenario_run_history, :scenario_type
+  end
+end

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.0'
 end

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '0.1.99'
+  VERSION = '1.0.0'.freeze
 end

--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -31,8 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'linkeddata'
 
   # Produces dashboard charts on monitor status page
-  spec.add_dependency 'chartkick'
+  spec.add_dependency 'gruff'
 
+  spec.add_development_dependency 'binding_of_caller', '~> 1.0.0' # rubocop styleguide
   spec.add_development_dependency 'bixby', '~> 1.0.0' # rubocop styleguide
   # spec.add_development_dependency 'capybara', '~> 2.13'
   spec.add_development_dependency 'engine_cart', '~> 2.0'

--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'qa' # loaded specific branch in Gemfile
   spec.add_development_dependency 'linkeddata'
 
+  # Produces dashboard charts on monitor status page
+  spec.add_dependency 'chartkick'
+
   spec.add_development_dependency 'bixby', '~> 1.0.0' # rubocop styleguide
   # spec.add_development_dependency 'capybara', '~> 2.13'
   spec.add_development_dependency 'engine_cart', '~> 2.0'

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -2,4 +2,5 @@
 
 group :development do
   gem 'better_errors'
+  gem 'binding_of_caller'
 end


### PR DESCRIPTION
### Completed

* was saving just failures, but decided it was meaningful to know how long an authority had been up and running by including passing run data as well
* updates monitor status page to include a graph showing failing:passing test ratio
* updated to follow bixby rules in the new history code

### NEED TO:

Filter historical data to include only one run per day to avoid giving a false impression on the length of time an authority has been installed.  Multiple runs can occur on a day when `refresh` parameter is passed to the monitor status page during app interactive testing.
