### PR TITLE
drive main nav menu from presenter

### DIFF
--- a/app/presenters/qa_server/navmenu_presenter.rb
+++ b/app/presenters/qa_server/navmenu_presenter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# This presenter class provides all data needed by the view that show the list of authorities.
+module QaServer
+  class NavmenuPresenter
+    include QaServer::Engine.routes.url_helpers
+
+    # @return [Array<Hash>] label-url pairs for the navigation bar's menu items justified left
+    # @example
+    #   [
+    #     { label: 'Home', url: '/' },
+    #     { label: 'Usage', url: '/usage' },
+    #     { label: 'Authorities', url: '/authorities' },
+    #     { label: 'Check Status', url: '/check_status' },
+    #     { label: 'Monitor Status', url: '/monitor_status' }
+    #   ]
+    attr_reader :leftmenu_items
+
+    # @return [Array<Hash>] label-url pairs for the navigation bar's menu items justified right
+    # @example
+    #   [
+    #     { label: 'LD4L Gateway', url: 'http://ld4l.org' }
+    #   ]
+    attr_reader :rightmenu_items
+
+    def initialize
+      @leftmenu_items = []
+      @leftmenu_items << { label: I18n.t("qa_server.menu.home"), url: root_path }
+      @leftmenu_items << { label: I18n.t("qa_server.menu.usage"), url: usage_index_path }
+      @leftmenu_items << { label: I18n.t("qa_server.menu.authorities"), url: authority_list_index_path }
+      @leftmenu_items << { label: I18n.t("qa_server.menu.check_status"), url: check_status_index_path }
+      @leftmenu_items << { label: I18n.t("qa_server.menu.monitor_status"), url: monitor_status_index_path }
+
+      @rightmenu_items = []
+      @rightmenu_items << { label: "LD4L Gateway", url: "http://ld4l.org/" }
+    end
+
+    # Append additional left justified menu items to the main navigation menu
+    # @param [Array<Hash<String,String>>] array of menu items to append with hash key = menu item label to display and hash value = URL for the menu item link
+    # @example
+    #   [
+    #     { label: 'New Item Label', url: 'http://new.item/one' },
+    #     { label: '2nd New Item Label', url: 'http://new.item/two' }
+    #   ]
+    def append_leftmenu_items(additional_items = [])
+      return if additional_items.nil?
+      additional_items.each { |item| @leftmenu_items << item }
+    end
+  end
+end

--- a/app/views/layouts/qa_server.html.erb
+++ b/app/views/layouts/qa_server.html.erb
@@ -33,17 +33,16 @@
     <div class="container-fluid">
       <div class="navbar-header">
         <ul class="nav-menu">
-          <li class="left-menu"><%= link_to t("qa_server.menu.home"), main_app.root_path %></li>
-          <li class="left-menu"><%= link_to t("qa_server.menu.usage"), qa_server.usage_index_path %></li>
-          <li class="left-menu"><%= link_to t("qa_server.menu.authorities"), qa_server.authority_list_index_path %></li>
-          <li class="left-menu"><%= link_to t("qa_server.menu.check_status"), qa_server.check_status_index_path %></li>
-          <li class="left-menu"><%= link_to t("qa_server.menu.monitor_status"), qa_server.monitor_status_index_path %></li>
-          <li class="right-menu"><%= link_to "LD4L Gateway", "http://ld4l.org/" %></li>
+          <% QaServer.config.navmenu_presenter.leftmenu_items.each do |item| %>
+            <li class='left-menu'><%= link_to item[:label], item[:url] %></li>
+          <% end %>
+          <% QaServer.config.navmenu_presenter.rightmenu_items.each do |item| %>
+            <li class='right-menu'><%= link_to item[:label], item[:url] %></li>
+          <% end %>
         </ul>
       </div>
     </div>
   </nav>
-</div>
 </div>
 
 <div id="content-wrapper" class="container" role="main">

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -60,6 +60,7 @@ en:
       history:
         title:         History
         since:         'Since %{date} ET'
+        authority:     Authority
         days_failing:  Days Failing
         days_passing:  Days Passing
         days_tested:   Days Tested

--- a/lib/generators/qa_server/templates/config/initializers/qa_server.rb
+++ b/lib/generators/qa_server/templates/config/initializers/qa_server.rb
@@ -7,4 +7,10 @@ QaServer.config do |config|
   # Displays a datatable of historical test data when true
   # @param [Boolean] display history datatable when true
   # config.display_historical_datatable = true
+
+  # Additional menu items to add to the main navigation menu's set of left justified menu items
+  # @param [Array<Hash<String,String>>] array of menu items to append with hash label: is menu item label to display and hash url: is URL for the menu item link
+  # config.navmenu_extra_leftitems = [
+  #   { label: 'Your Menu Item Label', url: 'http://your.menu.item/url' }
+  # ]
 end

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -12,5 +12,23 @@ module QaServer
       return @display_historical_datatable unless @display_historical_datatable.nil?
       @display_historical_datatable = true
     end
+
+    # Additional menu items to add to the main navigation menu's set of left justified menu items
+    # @param [Array<Hash<String,String>>] array of menu items to append with hash key = menu item label to display and hash value = URL for the menu item link
+    # @example
+    #   [
+    #     { label: 'New Item Label', url: 'http://new.item/one' },
+    #     { label: '2nd New Item Label', url: 'http://new.item/two' }
+    #   ]
+    attr_accessor :navmenu_extra_leftitems
+
+    # Get the one and only instance of the navigation menu presenter used to construct the main navigation menu.
+    # To extend, set additional navigation menu items using #navmenu_extra_leftitems
+    def navmenu_presenter
+      return @navmenu_presenter if @navmenu_presenter.present?
+      @navmenu_presenter ||= QaServer::NavmenuPresenter.new
+      @navmenu_presenter.append_leftmenu_items(navmenu_extra_leftitems)
+      @navmenu_presenter
+    end
   end
 end

--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
   # Produces dashboard charts on monitor status page
   spec.add_dependency 'gruff'
 
-  spec.add_development_dependency 'binding_of_caller', '~> 1.0.0' # rubocop styleguide
+  spec.add_development_dependency 'better_errors'
+  spec.add_development_dependency 'binding_of_caller'
   spec.add_development_dependency 'bixby', '~> 1.0.0' # rubocop styleguide
   # spec.add_development_dependency 'capybara', '~> 2.13'
   spec.add_development_dependency 'engine_cart', '~> 2.0'


### PR DESCRIPTION
Allows apps to extend the main nav menu.  This allows apps to install API docs and have a menu item that goes to the docs.