### PR TITLE
add performance data to monitor status page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ script/log
 /public/documents
 /public/assets
 /public/sitemap.xml.gz
+/app/assets/images/qa_server/charts/*
 
 # ignore renderer file
 # shows the template being rendered in the html source

--- a/app/assets/stylesheets/qa_server/_monitor-status.scss
+++ b/app/assets/stylesheets/qa_server/_monitor-status.scss
@@ -11,3 +11,37 @@ p.status-update-dtstamp {
   color: darkred;
   font-style: italic;
 }
+
+div.right-menu-section {
+  padding-top: 50px;
+}
+
+ul.right-menu {
+  list-style-type: none;
+  li.clickable {
+    display: inline;
+    padding-right: 30px;
+    color: #337ab7;
+  }
+  li.clickable:hover {
+    color: #23527c;
+    text-decoration: underline;
+  }
+  li.selected {
+    display: inline;
+    padding-right: 30px;
+    font-weight: bold;
+  }
+}
+
+div#performance-by-the-hour {
+  display: block;
+}
+
+div#performance-by-the-day {
+  display: none;
+}
+
+div#performance-by-the-month {
+  display: none;
+}

--- a/app/controllers/qa_server/monitor_status_controller.rb
+++ b/app/controllers/qa_server/monitor_status_controller.rb
@@ -4,11 +4,13 @@ module QaServer
   class MonitorStatusController < QaServer::AuthorityValidationController
     class_attribute :presenter_class,
                     :scenario_run_registry_class,
-                    :scenario_history_class
+                    :scenario_history_class,
+                    :performance_history_class
 
     self.presenter_class = QaServer::MonitorStatusPresenter
     self.scenario_run_registry_class = QaServer::ScenarioRunRegistry
     self.scenario_history_class = QaServer::ScenarioRunHistory
+    self.performance_history_class = QaServer::PerformanceHistory
 
     # Sets up presenter with data to display in the UI
     def index
@@ -20,7 +22,7 @@ module QaServer
       @presenter = presenter_class.new(current_summary: latest_summary,
                                        current_failure_data: latest_failures,
                                        historical_summary_data: historical_summary_data,
-                                       performance_data: [])
+                                       performance_data: performance_history_class.performance_data)
       render 'index', status: :internal_server_error if latest_summary.failing_authority_count.positive?
     end
 

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+# Provide access to the scenario_results_history database table which tracks specific scenario runs over time.
+module QaServer
+  class PerformanceHistory < ActiveRecord::Base
+    self.table_name = 'performance_history'
+
+    enum action: [:fetch, :search]
+
+    PERFORMANCE_FOR_DAY_KEY = :day
+    PERFORMANCE_BY_HOUR_KEY = :hour
+
+    PERFORMANCE_FOR_MONTH_KEY = :month
+    PERFORMANCE_BY_DAY_KEY = :day
+
+    PERFORMANCE_FOR_YEAR_KEY = :year
+    PERFORMANCE_BY_MONTH_KEY = :month
+
+    LOAD_TIME_KEY = :load_avg_ms
+    NORMALIZATION_TIME_KEY = :normalization_avg_ms
+    COMBINED_TIME_KEY = :combined_avg_ms
+
+    class << self
+
+      # Save a scenario result
+      # @param run_id [Integer] the run on which to gather statistics
+      # @param result [Hash] the scenario result to be saved
+      def save_result(dt_stamp:, authority:, action:, size_bytes:, load_time_ms:, normalization_time_ms: )
+        QaServer::PerformanceHistory.create(dt_stamp: dt_stamp,
+                                            authority: authority,
+                                            action: action,
+                                            size_bytes: size_bytes,
+                                            load_time_ms: load_time_ms,
+                                            normalization_time_ms: normalization_time_ms)
+      end
+
+      # Performance data for a day, a month, and a year.
+      # @returns [Hash] performance statistics for the past 24 hours
+      # @example
+      #   { 0: { hour: 1400, load_avg_ms: 12.3, normalization_avg_ms: 4.2 },
+      #     1: { hour: 1500, load_avg_ms: 12.3, normalization_avg_ms: 4.2 },
+      #     2: { hour: 1600, load_avg_ms: 12.3, normalization_avg_ms: 4.2 },
+      #     ...,
+      #     23: { hour: 1300, load_avg_ms: 12.3, normalization_avg_ms: 4.2 }
+      #   }
+      def performance_data
+        data = {}
+        data[PERFORMANCE_FOR_DAY_KEY] = average_last_24_hours
+        data[PERFORMANCE_FOR_MONTH_KEY] = average_last_30_days
+        data[PERFORMANCE_FOR_YEAR_KEY] = average_last_12_months
+        data
+      end
+
+      private
+
+        # Get hourly average for the past 24 hours.
+        # @returns [Hash] performance statistics for the past 24 hours
+        # @example
+        #   { 0: { hour: 1400, load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     1: { hour: 1500, load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     2: { hour: 1600, load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     ...,
+        #     23: { hour: 1300, load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 }
+        #   }
+        def average_last_24_hours
+          start_hour = Time.now.beginning_of_hour - 23.hour
+          avgs = {}
+          0.upto(23).each do |idx|
+            records = PerformanceHistory.where(dt_stamp: start_hour..start_hour.end_of_hour)
+            averages = calculate_averages(records)
+            data = {}
+            data[PERFORMANCE_BY_HOUR_KEY] = idx == 23 ? I18n.t('qa_server.monitor_status.performance.now') : ((idx + 1) % 2 == 0 ? (start_hour.hour * 100).to_s : "")
+            data[LOAD_TIME_KEY] = averages[:avg_load_time_ms]
+            data[NORMALIZATION_TIME_KEY] = averages[:avg_normalization_time_ms]
+            data[COMBINED_TIME_KEY] = averages[:avg_combined_time_ms]
+            avgs[idx] = data
+            start_hour = start_hour + 1.hour
+          end
+          avgs
+        end
+
+        # Get daily average for the past 30 days.
+        # @returns [Hash] performance statistics for the past 30 days
+        # @example
+        #   { 0: { day: '07-15-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     1: { day: '07-16-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     2: { day: '07-17-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     ...,
+        #     29: { day: '08-13-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 }
+        #   }
+        def average_last_30_days
+          start_day = Time.now.beginning_of_day - 29.day
+          avgs = {}
+          0.upto(29).each do |idx|
+            records = PerformanceHistory.where(dt_stamp: start_day..start_day.end_of_day)
+            averages = calculate_averages(records)
+            data = {}
+            data[PERFORMANCE_BY_DAY_KEY] = idx == 29 ? I18n.t('qa_server.monitor_status.performance.today') : ((idx + 1) % 5 == 0 ? (start_day).strftime("%m-%d") : "")
+            data[LOAD_TIME_KEY] = averages[:avg_load_time_ms]
+            data[NORMALIZATION_TIME_KEY] = averages[:avg_normalization_time_ms]
+            data[COMBINED_TIME_KEY] = averages[:avg_combined_time_ms]
+            avgs[idx] = data
+            start_day = start_day + 1.day
+          end
+          avgs
+        end
+
+        # Get daily average for the past 12 months.
+        # @returns [Hash] performance statistics for the past 12 months
+        # @example
+        #   { 0: { month: '09-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     1: { month: '10-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     2: { month: '11-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 },
+        #     ...,
+        #     11: { month: '08-2019', load_avg_ms: 12.3, normalization_avg_ms: 4.2, combined_avg_ms: 16.5 }
+        #   }
+        def average_last_12_months
+          start_month = Time.now.beginning_of_month - 11.month
+          avgs = {}
+          0.upto(11).each do |idx|
+            records = PerformanceHistory.where(dt_stamp: start_month..start_month.end_of_month)
+            averages = calculate_averages(records)
+            data = {}
+            data[PERFORMANCE_BY_MONTH_KEY] = (start_month).strftime("%m-%Y")
+            data[LOAD_TIME_KEY] = averages[:avg_load_time_ms]
+            data[NORMALIZATION_TIME_KEY] = averages[:avg_normalization_time_ms]
+            data[COMBINED_TIME_KEY] = averages[:avg_combined_time_ms]
+            avgs[idx] = data
+            start_month = start_month + 1.month
+          end
+          avgs
+        end
+
+        def calculate_averages(records)
+          return { avg_load_time_ms: 0, avg_normalization_time_ms: 0, avg_combined_time_ms: 0 } if records.count.zero?
+          sum_load_times = 0
+          sum_normalization_times = 0
+          sum_combined_times = 0
+          records.each do |record|
+            sum_load_times += record.load_time_ms
+            sum_normalization_times += record.normalization_time_ms
+            sum_combined_times += (record.load_time_ms + record.normalization_time_ms)
+          end
+          {
+            avg_load_time_ms: sum_load_times / records.count,
+            avg_normalization_time_ms: sum_normalization_times / records.count,
+            avg_combined_time_ms: sum_combined_times / records.count
+          }
+        end
+    end
+  end
+end

--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -1,0 +1,16 @@
+module PrependedLinkedData::FindTerm
+  # Override Qa::Authorities::LinkedData::FindTerm#find method
+  # @return [Hash] single term results in requested format
+  def find(id, language: nil, replacements: {}, subauth: nil, format: nil, jsonld: false, performance_data: false) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+    saved_performance_data = performance_data
+    performance_data = true
+    full_results = super
+    QaServer::PerformanceHistory.save_result(dt_stamp: Time.now,
+                                             authority: authority_name,
+                                             action: 'fetch',
+                                             size_bytes: full_results[:performance][:fetched_bytes],
+                                             load_time_ms: (full_results[:performance][:fetch_time_s] * 1000),
+                                             normalization_time_ms: (full_results[:performance][:normalization_time_s] * 1000))
+    saved_performance_data ? full_results : full_results[:results]
+  end
+end

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -1,0 +1,16 @@
+module PrependedLinkedData::SearchQuery
+  # Override Qa::Authorities::LinkedData::SearchQuery#search method
+  # @return [String] json results for search query
+  def search(query, language: nil, replacements: {}, subauth: nil, context: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
+    saved_performance_data = performance_data
+    performance_data = true
+    full_results = super
+    QaServer::PerformanceHistory.save_result(dt_stamp: Time.now,
+                                             authority: authority_name,
+                                             action: 'search',
+                                             size_bytes: full_results[:performance][:fetched_bytes],
+                                             load_time_ms: (full_results[:performance][:fetch_time_s] * 1000),
+                                             normalization_time_ms: (full_results[:performance][:normalization_time_s] * 1000))
+    saved_performance_data ? full_results : full_results[:results]
+  end
+end

--- a/app/presenters/qa_server/monitor_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status_presenter.rb
@@ -6,13 +6,27 @@ require 'gruff'
 # This presenter class provides all data needed by the view that monitors status of authorities.
 module QaServer
   class MonitorStatusPresenter # rubocop:disable Metrics/ClassLength
+    class_attribute :performance_history_class
+    self.performance_history_class = QaServer::PerformanceHistory
+
     HISTORICAL_AUTHORITY_NAME_IDX = 0
     HISTORICAL_FAILURE_COUNT_IDX = 1
     HISTORICAL_PASSING_COUNT_IDX = 2
 
+    PERFORMANCE_FOR_DAY_KEY = performance_history_class::PERFORMANCE_FOR_DAY_KEY
+    PERFORMANCE_BY_HOUR_KEY = performance_history_class::PERFORMANCE_BY_HOUR_KEY
+    PERFORMANCE_FOR_MONTH_KEY = performance_history_class::PERFORMANCE_FOR_MONTH_KEY
+    PERFORMANCE_BY_DAY_KEY = performance_history_class::PERFORMANCE_BY_DAY_KEY
+    PERFORMANCE_FOR_YEAR_KEY = performance_history_class::PERFORMANCE_FOR_YEAR_KEY
+    PERFORMANCE_BY_MONTH_KEY = performance_history_class::PERFORMANCE_BY_MONTH_KEY
+    LOAD_TIME_KEY = performance_history_class::LOAD_TIME_KEY
+    NORMALIZATION_TIME_KEY = performance_history_class::NORMALIZATION_TIME_KEY
+    COMBINED_TIME_KEY = performance_history_class::COMBINED_TIME_KEY
+
     # @param current_summary [ScenarioRunSummary] summary status of the latest run of test scenarios
     # @param current_data [Array<Hash>] current set of failures for the latest test run, if any
     # @param historical_summary_data [Array<Hash>] summary of past failuring runs per authority to drive chart
+    # @param performance_data [Hash<Hash>] performance data
     def initialize(current_summary:, current_failure_data:, historical_summary_data:, performance_data:)
       @current_summary = current_summary
       @current_failure_data = current_failure_data
@@ -101,14 +115,14 @@ module QaServer
     def historical_graph
       # g = Gruff::SideStackedBar.new('800x400')
       g = Gruff::SideStackedBar.new
-      graph_theme(g)
+      historical_graph_theme(g)
       g.title = ''
       historical_data = rework_historical_data_for_gruff
       g.labels = historical_data[0]
       g.data('Fail', historical_data[1])
       g.data('Pass', historical_data[2])
       g.write historical_graph_full_path
-      File.join(historical_graph_relative_path, historical_graph_filename)
+      File.join(graph_relative_path, historical_graph_filename)
     end
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
@@ -175,23 +189,52 @@ module QaServer
       QaServer.config.display_historical_datatable?
     end
 
+    def performance_data?
+      @performance_data.present?
+    end
+
+    def performance_for_day_graph
+      performance_graph_file(rework_performance_data_for_gruff(@performance_data[PERFORMANCE_FOR_DAY_KEY], :hour),
+                             performance_for_day_graph_full_path,
+                             performance_for_day_graph_filename,
+                             I18n.t('qa_server.monitor_status.performance.x_axis_hour'))
+    end
+
+    def performance_for_month_graph
+      performance_graph_file(rework_performance_data_for_gruff(@performance_data[PERFORMANCE_FOR_MONTH_KEY], :day),
+                             performance_for_month_graph_full_path,
+                             performance_for_month_graph_filename,
+                             I18n.t('qa_server.monitor_status.performance.x_axis_day'))
+    end
+
+    def performance_for_year_graph
+      performance_graph_file(rework_performance_data_for_gruff(@performance_data[PERFORMANCE_FOR_YEAR_KEY], :month),
+                             performance_for_year_graph_full_path,
+                             performance_for_year_graph_filename,
+                             I18n.t('qa_server.monitor_status.performance.x_axis_month'))
+    end
+
     private
 
-      def graph_theme(g)
+      def historical_graph_theme(g)
         g.theme_pastel
         g.colors = ['#ffcccc', '#ccffcc']
         g.marker_font_size = 12
         g.x_axis_increment = 10
       end
 
-      def historical_graph_full_path
-        path = Rails.root.join('app', 'assets', 'images', historical_graph_relative_path)
-        FileUtils.mkdir_p path
-        File.join(path, historical_graph_filename)
+      def graph_relative_path
+        File.join('qa_server', 'charts')
       end
 
-      def historical_graph_relative_path
-        File.join('qa_server', 'charts')
+      def graph_full_path(graph_filename)
+        path = Rails.root.join('app', 'assets', 'images', graph_relative_path)
+        FileUtils.mkdir_p path
+        File.join(path, graph_filename)
+      end
+
+      def historical_graph_full_path
+        graph_full_path(historical_graph_filename)
       end
 
       def historical_graph_filename
@@ -210,6 +253,69 @@ module QaServer
           pass_data << data[2]
         end
         [labels, fail_data, pass_data]
+      end
+
+      def performance_graph_theme(g, x_axis_label)
+        g.theme_pastel
+        g.colors = ['#81adf4', '#8696b0', '#06578a']
+        g.marker_font_size = 12
+        g.x_axis_increment = 10
+        g.x_axis_label = x_axis_label
+        g.y_axis_label = I18n.t('qa_server.monitor_status.performance.y_axis_ms')
+        g.dot_radius = 3
+        g.line_width = 2
+        g.minimum_value = 0
+        g.maximum_value = 1000
+      end
+
+      def performance_for_day_graph_filename
+        'performance_for_day_graph.png'
+      end
+
+      def performance_for_day_graph_full_path
+        graph_full_path(performance_for_day_graph_filename)
+      end
+
+      def performance_for_month_graph_filename
+        'performance_for_month_graph.png'
+      end
+
+      def performance_for_month_graph_full_path
+        graph_full_path(performance_for_month_graph_filename)
+      end
+
+      def performance_for_year_graph_filename
+        'performance_for_year_graph.png'
+      end
+
+      def performance_for_year_graph_full_path
+        graph_full_path(performance_for_year_graph_filename)
+      end
+
+      def rework_performance_data_for_gruff(performance_data, label_key)
+        labels = {}
+        load_data = []
+        normalization_data = []
+        combined_data = []
+        performance_data.each do |i, data|
+          labels[i] = data[label_key]
+          load_data << data[LOAD_TIME_KEY]
+          normalization_data << data[NORMALIZATION_TIME_KEY]
+          combined_data << data[COMBINED_TIME_KEY]
+        end
+        [labels, load_data, normalization_data, combined_data]
+      end
+
+      def performance_graph_file(performance_data, performance_graph_full_path, performance_graph_filename, x_axis_label)
+        g = Gruff::Line.new
+        performance_graph_theme(g, x_axis_label)
+        g.title = ''
+        g.labels = performance_data[0]
+        g.data(I18n.t('qa_server.monitor_status.performance.load_time_ms'), performance_data[1])
+        g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[2])
+        g.data(I18n.t('qa_server.monitor_status.performance.combined_time_ms'), performance_data[3])
+        g.write performance_graph_full_path
+        File.join(graph_relative_path, performance_graph_filename)
       end
   end
 end

--- a/app/views/qa_server/monitor_status/index.html.erb
+++ b/app/views/qa_server/monitor_status/index.html.erb
@@ -26,7 +26,7 @@
   <p class="status-update-dtstamp"><%= t('qa_server.monitor_status.summary.last_updated', date: @presenter.last_updated) %></p>
 
   <% if @presenter.failures? %>
-    <div id="status-section" class="status-section">
+    <div id="failures" class="status-section">
       <h4><%= t('qa_server.monitor_status.failures.title') %></h4>
 
       <table class="status">
@@ -60,7 +60,7 @@
   <% end %>
 
   <% if @presenter.history? && @presenter.display_history_details?%>
-      <div id="status-section" class="status-section">
+      <div id="availability-history" class="status-section">
         <h3><%= t('qa_server.monitor_status.history.title') %></h3>
         <p class="status-update-dtstamp"><%= t('qa_server.monitor_status.history.since', date: @presenter.first_updated) %></p>
         <%#= column_chart @presenter.historical_summary, stacked: true, colors: ["green", "red"], xtitle: 'Authority', ytitle: 'Pass-Fail', legend: 'bottom' %>
@@ -89,5 +89,65 @@
           </table>
         <% end %>
       </div>
+  <% end %>
+
+  <% if @presenter.performance_data? %>
+    <div id="performance-data" class="status-section">
+      <h3><%= t('qa_server.monitor_status.performance.title') %></h3>
+
+      <script>
+        function switch_performance_view(id) {
+            document.getElementById('performance-by-the-hour').style.display = 'none';
+            document.getElementById('performance-by-the-day').style.display = 'none';
+            document.getElementById('performance-by-the-month').style.display = 'none';
+            document.getElementById(id).style.display = 'block';
+        }
+      </script>
+
+      <div id="performance-by-the-hour" class="performance-data-section">
+        <div id="right-menu-section">
+          <ul class="right-menu">
+            <li class="selected"><%= t('qa_server.monitor_status.performance.menu_day') %></li>
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-day')"><%= t('qa_server.monitor_status.performance.menu_month') %></li>
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-month')"><%= t('qa_server.monitor_status.performance.menu_year') %></li>
+          </ul>
+        </div>
+
+        <div id="performance-chart-by-the-hour" class="performance-chart">
+          <p>Data for the last 24 hours</p>
+          <%= image_tag(@presenter.performance_for_day_graph, alt: 'Performance data for the last 24 hours.') %>
+        </div>
+      </div>
+
+      <div id="performance-by-the-day" class="performance-data-section">
+        <div id="right-menu-section">
+          <ul class="right-menu">
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-hour')"><%= t('qa_server.monitor_status.performance.menu_day') %></li>
+            <li class="selected"><%= t('qa_server.monitor_status.performance.menu_month') %></li>
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-month')"><%= t('qa_server.monitor_status.performance.menu_year') %></li>
+          </ul>
+        </div>
+
+        <div id="performance-chart-by-the-day" class="performance-chart">
+          <p>Data for the last 30 days</p>
+          <%= image_tag(@presenter.performance_for_month_graph, alt: 'Performance data for the last 30 days.') %>
+        </div>
+      </div>
+
+      <div id="performance-by-the-month" class="performance-data-section">
+        <div id="right-menu-section">
+          <ul class="right-menu">
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-hour')"><%= t('qa_server.monitor_status.performance.menu_day') %></li>
+            <li class="clickable" onClick="switch_performance_view('performance-by-the-day')"><%= t('qa_server.monitor_status.performance.menu_month') %></li>
+            <li class="selected"><%= t('qa_server.monitor_status.performance.menu_year') %></li>
+          </ul>
+        </div>
+
+        <div id="performance-chart-by-the-month" class="performance-chart">
+          <p>Data for the last 12 months</p>
+          <%= image_tag(@presenter.performance_for_year_graph, alt: 'Performance data for the last 12 months.') %>
+        </div>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -74,5 +74,19 @@ en:
         days_passing:    Days Passing
         days_tested:     Days Tested
         percent_failing: Percent Failing
+      performance:
+        title:           Performance Metrics
+        menu_day:        Day
+        menu_month:      Month
+        menu_year:       Year
+        load_time_ms:          Load Time (ms)
+        normalization_time_ms: Normalization Time (ms)
+        combined_time_ms:      Full Request Time (ms)
+        x_axis_hour:     Hour
+        x_axis_day:      Day
+        x_axis_month:    Month
+        y_axis_ms:       Milliseconds (ms)
+        now:             NOW
+        today:           TODAY
     usage:
       title:             Usage

--- a/lib/generators/qa_server/config_generator.rb
+++ b/lib/generators/qa_server/config_generator.rb
@@ -34,4 +34,13 @@ class QaServer::ConfigGenerator < Rails::Generators::Base
   def create_initializer_config_file
     copy_file 'config/initializers/qa_server.rb'
   end
+
+  def append_prepends
+    inject_into_file 'config/application.rb', after: /Rails::Application/ do
+      "\n      config.to_prepare do"\
+      "\n        Qa::Authorities::LinkedData::FindTerm.prepend PrependedLinkedData::FindTerm"\
+      "\n        Qa::Authorities::LinkedData::SearchQuery.prepend PrependedLinkedData::SearchQuery"\
+      "\n      end\n"
+    end
+  end
 end

--- a/lib/generators/qa_server/templates/db/migrate/20190813045549_create_performance_history.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20190813045549_create_performance_history.rb.erb
@@ -1,0 +1,12 @@
+class CreatePerformanceHistory < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :performance_history do |t|
+      t.datetime :dt_stamp
+      t.string :authority
+      t.string :action
+      t.integer :size_bytes
+      t.float :load_time_ms
+      t.float :normalization_time_ms
+    end
+  end
+end


### PR DESCRIPTION
Work in this PR...
* UI to display performance data as graphs on the monitor status page
* saves search query & term fetch performance data to database for every request
* calculates averages for load, normalization, and combined times
* calculates averages for last 24 hours, last 30 days, and last 12 months

Currently splits on time periods: day, month, year

Might also want to split on:
* action: fetch, search
* per authority