### PR TITLE
switch performance graph to stacked_bar

### DIFF
--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -107,7 +107,7 @@ module QaServer
                     records_for_last_30_days(auth_name) ||
                     records_for_last_12_months(auth_name) ||
                     all_records(auth_name)
-          stats = stats_calculator_class.new(records).calculate_stats
+          stats_calculator_class.new(records).calculate_stats(avg: true, low: true, high: true)
         end
 
         def expected_time_period

--- a/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
@@ -59,13 +59,13 @@ module QaServer::MonitorStatus
     def performance_table_description
       case expected_time_period
       when :day
-        I18n.t('qa_server.monitor_status.performance.datatable_day_desc', )
+        I18n.t('qa_server.monitor_status.performance.datatable_day_desc')
       when :month
-        I18n.t('qa_server.monitor_status.performance.datatable_month_desc', )
+        I18n.t('qa_server.monitor_status.performance.datatable_month_desc')
       when :year
-        I18n.t('qa_server.monitor_status.performance.datatable_year_desc', )
+        I18n.t('qa_server.monitor_status.performance.datatable_year_desc')
       else
-        I18n.t('qa_server.monitor_status.performance.datatable_all_desc', )
+        I18n.t('qa_server.monitor_status.performance.datatable_all_desc')
       end
     end
 

--- a/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
@@ -63,7 +63,7 @@ module QaServer::MonitorStatus
 
     private
 
-      def default_graph?(graph_info)
+      def default_graph?(graph_info) # rubocop:disable Metrics/CyclomaticComplexity
         return true if QaServer.config.performance_graph_default_time_period == :day && performance_day_graph_selected?(graph_info)
         return true if QaServer.config.performance_graph_default_time_period == :month && performance_month_graph_selected?(graph_info)
         return true if QaServer.config.performance_graph_default_time_period == :year && performance_year_graph_selected?(graph_info)

--- a/app/services/qa_server/performance_calculator_service.rb
+++ b/app/services/qa_server/performance_calculator_service.rb
@@ -20,31 +20,31 @@ module QaServer
     # { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
     #   load_min_ms: 12.3, normalization_min_ms: 4.2, full_request_min_ms: 16.5,
     #   load_max_ms: 12.3, normalization_max_ms: 4.2, full_request_max_ms: 16.5 }
-    def calculate_stats
-      calculate_load_stats
-      calculate_norm_stats
-      calculate_full_stats
+    def calculate_stats(avg: false, low: false, high: false, load: true, norm: true, full: true)
+      calculate_load_stats(avg, low, high)
+      calculate_norm_stats(avg, low, high)
+      calculate_full_stats(avg, low, high) if full
       stats
     end
 
     private
 
-      def calculate_load_stats
-        stats[AVG_LOAD] = calculate_average(load_times)
-        stats[LOW_LOAD] = calculate_10th_percentile(load_times_sorted)
-        stats[HIGH_LOAD] = calculate_90th_percentile(load_times_sorted)
+      def calculate_load_stats(avg, low, high)
+        stats[AVG_LOAD] = calculate_average(load_times) if avg
+        stats[LOW_LOAD] = calculate_10th_percentile(load_times_sorted) if low
+        stats[HIGH_LOAD] = calculate_90th_percentile(load_times_sorted) if high
       end
 
-      def calculate_norm_stats
-        stats[AVG_NORM] = calculate_average(norm_times)
-        stats[LOW_NORM] = calculate_10th_percentile(norm_times_sorted)
-        stats[HIGH_NORM] = calculate_90th_percentile(norm_times_sorted)
+      def calculate_norm_stats(avg, low, high)
+        stats[AVG_NORM] = calculate_average(norm_times) if avg
+        stats[LOW_NORM] = calculate_10th_percentile(norm_times_sorted) if low
+        stats[HIGH_NORM] = calculate_90th_percentile(norm_times_sorted) if high
       end
 
-      def calculate_full_stats
-        stats[AVG_FULL] = calculate_average(full_times)
-        stats[LOW_FULL] = calculate_10th_percentile(full_times_sorted)
-        stats[HIGH_FULL] = calculate_90th_percentile(full_times_sorted)
+      def calculate_full_stats(avg, low, high)
+        stats[AVG_FULL] = calculate_average(full_times) if avg
+        stats[LOW_FULL] = calculate_10th_percentile(full_times_sorted) if low
+        stats[HIGH_FULL] = calculate_90th_percentile(full_times_sorted) if high
       end
 
       def count
@@ -52,7 +52,7 @@ module QaServer
       end
 
       def tenth_percentile_count
-        @tenth_percentile_count ||= (records.count*0.1).round
+        @tenth_percentile_count ||= (records.count * 0.1).round
       end
 
       def load_times
@@ -84,11 +84,11 @@ module QaServer
       end
 
       def calculate_10th_percentile(sorted_times)
-        sorted_times[tenth_percentile_count-1]
+        sorted_times[tenth_percentile_count - 1]
       end
 
       def calculate_90th_percentile(sorted_times)
-        sorted_times[count-tenth_percentile_count]
+        sorted_times[count - tenth_percentile_count]
       end
   end
 end

--- a/app/services/qa_server/performance_graph_data_service.rb
+++ b/app/services/qa_server/performance_graph_data_service.rb
@@ -25,7 +25,7 @@ module QaServer
           where_clause = { dt_stamp: start_hour..start_hour.end_of_hour }
           where_clause[:authority] = auth_name unless auth_name.nil?
           records = performance_data_class.where(where_clause)
-          stats = stats_calculator_class.new(records).calculate_stats
+          stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
           data = {}
           data[BY_HOUR] = performance_by_hour_label(idx, start_hour)
           data[STATS] = stats
@@ -51,7 +51,7 @@ module QaServer
           where_clause = { dt_stamp: start_day..start_day.end_of_day }
           where_clause[:authority] = auth_name unless auth_name.nil?
           records = performance_data_class.where(where_clause)
-          stats = stats_calculator_class.new(records).calculate_stats
+          stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
           data = {}
           data[BY_DAY] = performance_by_day_label(idx, start_day)
           data[STATS] = stats
@@ -77,7 +77,7 @@ module QaServer
           where_clause = { dt_stamp: start_month..start_month.end_of_month }
           where_clause[:authority] = auth_name unless auth_name.nil?
           records = performance_data_class.where(where_clause)
-          stats = stats_calculator_class.new(records).calculate_stats
+          stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
           data = {}
           data[BY_MONTH] = start_month.strftime("%m-%Y")
           data[STATS] = stats

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -61,15 +61,12 @@ module QaServer
 
         def performance_graph_theme(g, x_axis_label)
           g.theme_pastel
-          g.colors = [QaServer.config.performance_load_color,
-                      QaServer.config.performance_normalization_color,
-                      QaServer.config.performance_full_request_color]
+          g.colors = [QaServer.config.performance_normalization_color,
+                      QaServer.config.performance_load_color]
           g.marker_font_size = 12
           g.x_axis_increment = 10
           g.x_axis_label = x_axis_label
           g.y_axis_label = I18n.t('qa_server.monitor_status.performance.y_axis_ms')
-          g.dot_radius = 3
-          g.line_width = 2
           g.minimum_value = 0
           g.maximum_value = 2000
         end
@@ -94,24 +91,21 @@ module QaServer
           labels = {}
           load_data = []
           normalization_data = []
-          full_request_data = []
           performance_data.each do |i, data|
             labels[i] = data[label_key]
             load_data << data[STATS][AVG_LOAD]
             normalization_data << data[STATS][AVG_NORM]
-            full_request_data << data[STATS][AVG_FULL]
           end
-          [labels, load_data, normalization_data, full_request_data]
+          [labels, normalization_data, load_data]
         end
 
         def create_gruff_graph(performance_data, performance_graph_full_path, x_axis_label)
-          g = Gruff::Line.new
+          g = Gruff::StackedBar.new
           performance_graph_theme(g, x_axis_label)
           g.title = ''
           g.labels = performance_data[0]
-          g.data(I18n.t('qa_server.monitor_status.performance.load_time_ms'), performance_data[1])
-          g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[2])
-          g.data(I18n.t('qa_server.monitor_status.performance.full_request_time_ms'), performance_data[3])
+          g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[1])
+          g.data(I18n.t('qa_server.monitor_status.performance.load_time_ms'), performance_data[2])
           g.write performance_graph_full_path
         end
     end

--- a/lib/generators/qa_server/templates/config/initializers/qa_server.rb
+++ b/lib/generators/qa_server/templates/config/initializers/qa_server.rb
@@ -15,17 +15,12 @@ QaServer.config do |config|
   # Color of the graph line for load times in the performance graphs.
   # @param [String] color RGB code
   # @note The default colors for the load, normalization, and full request lines in the performance graph are accessible.
-  # config.performance_load_color = '#CCBE9F'
+  # config.performance_load_color = '#ABC3C9'
 
   # Color of the graph line for normalization times (The default colors for the performance graph are accessible.)
   # @param [String] color RGB code
   # @note The default colors for the load, normalization, and full request lines in the performance graph are accessible.
-  # config.performance_normalization_color = '#ABC3C9'
-
-  # Color of the graph line for full request times (The default colors for the performance graph are accessible.)
-  # @param [String] color RGB code
-  # @note The default colors for the load, normalization, and full request lines in the performance graph are accessible.
-  # config.performance_full_request_color = '#382119'
+  # config.performance_normalization_color = '#CCBE9F'
 
   # Performance graph default time period for all graphs.  All authorities will show the graph for this time period on page load.
   # @param [String] :day, :month, or :year

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -29,21 +29,14 @@ module QaServer
     # @param [String] color RGB code
     attr_writer :performance_load_color
     def performance_load_color
-      @performance_load_color ||= '#CCBE9F'
+      @performance_load_color ||= '#ABC3C9'
     end
 
     # Color of the graph line for normalization times
     # @param [String] color RGB code
     attr_writer :performance_normalization_color
     def performance_normalization_color
-      @performance_normalization_color ||= '#ABC3C9'
-    end
-
-    # Color of the graph line for full request times
-    # @param [String] color RGB code
-    attr_writer :performance_full_request_color
-    def performance_full_request_color
-      @performance_full_request_color ||= '#382119'
+      @performance_normalization_color ||= '#CCBE9F'
     end
 
     # Performance graph default time period for all graphs.  All authorities will show the graph for this time period on page load.


### PR DESCRIPTION
* switch performance graph to stacked_bar
* don’t calculate low and high for graphs since they aren’t used
* don’t calcualte full request data for graphs since it isn’t used
* fix a few rubocop errors