### PR TITLE
do not extract and attempt to save non-existent performance data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Use 10th and 90th percentiles for datatable
 * display day graph for every authority for default time period
 * cache performance graphs
+* don’t calculate low and high for graphs since they aren’t used
+* don’t calcualte full request data for graphs since it isn’t used
 * include authority data for performance graphs
 * move some of the performance data construction code to services
 

--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -6,6 +6,7 @@ module PrependedLinkedData::FindTerm
     saved_performance_data = performance_data
     performance_data = true
     full_results = super
+    return full_results unless full_results.is_a?(Hash) && full_results.key?(:performance)
     QaServer::PerformanceHistory.save_result(dt_stamp: Time.now.getlocal,
                                              authority: authority_name,
                                              action: 'fetch',

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -6,6 +6,7 @@ module PrependedLinkedData::SearchQuery
     saved_performance_data = performance_data
     performance_data = true
     full_results = super
+    return full_results unless full_results.is_a?(Hash) && full_results.key?(:performance)
     QaServer::PerformanceHistory.save_result(dt_stamp: Time.now.getlocal,
                                              authority: authority_name,
                                              action: 'search',


### PR DESCRIPTION
If QA doesn’t return performance data, then just return the results without trying to process the non-existent performance data.  This fixes an exception that was thrown when fetching with format=jsonld.