### PR TITLE
prep for bug release 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.3 (2019-09-11)
+
+* do not process and store performance data if it wasn't returned in the result
+
 ### 2.2.2 (2019-09-10)
 
 * handle stat calculation and formatting when 0 records or missing stats

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '2.2.2'
+  VERSION = '2.2.3'
 end


### PR DESCRIPTION
Fixes bug where an exception was thrown when the fetch results didn't include performance data.  This happens when format=jsonld.