### PR TITLE
Rework performance data to add calculations/UI display per action

### DIFF
--- a/app/assets/stylesheets/qa_server/_authorities.scss
+++ b/app/assets/stylesheets/qa_server/_authorities.scss
@@ -1,3 +1,6 @@
-td.table_subheading {
+th.table_subheading, td.table_subheading {
   background-color: lightgrey;
+}
+th.table_subheading {
+  text-align: center;
 }

--- a/app/assets/stylesheets/qa_server/_check-status.scss
+++ b/app/assets/stylesheets/qa_server/_check-status.scss
@@ -73,6 +73,11 @@ td.position {
   background-color: #ffffff;
 }
 
+.status-not-supported {
+  text-align: center;
+  background-color: #F3EEEE;
+}
+
 label.horizontal-list {
   padding-right: 15px;
 }

--- a/app/assets/stylesheets/qa_server/_monitor-status.scss
+++ b/app/assets/stylesheets/qa_server/_monitor-status.scss
@@ -20,11 +20,11 @@ div.performance-data-section-visible {
   display: block;
 }
 
-div.right-menu-section {
+div.performance-graph-menu-section {
   padding-top: 50px;
 }
 
-ul.right-menu {
+ul.time-period-menu, ul.action-menu {
   list-style-type: none;
   li.clickable {
     display: inline;

--- a/app/models/concerns/qa_server/performance_history_data_keys.rb
+++ b/app/models/concerns/qa_server/performance_history_data_keys.rb
@@ -4,6 +4,10 @@
 module QaServer
   module PerformanceHistoryDataKeys
     ALL_AUTH = :all_authorities
+    SEARCH = :search
+    FETCH = :fetch
+    ALL_ACTIONS = :all_actions
+
     STATS = :stats
     FOR_DATATABLE = :datatable_stats
 
@@ -28,11 +32,11 @@ module QaServer
     AVG_NORM = :avg_normalization_ms
     AVG_ACTN = :avg_action_request_ms
     AVG_FULL = :avg_full_request_ms
-    HIGH_LOAD = :max_load_ms
-    HIGH_RETR = :max_retrieve_ms
-    HIGH_GRPH = :max_load_graph_ms
-    HIGH_NORM = :max_normalization_ms
-    HIGH_ACTN = :max_action_request_ms
-    HIGH_FULL = :max_full_request_ms
+    HIGH_LOAD = :high_load_ms
+    HIGH_RETR = :high_retrieve_ms
+    HIGH_GRPH = :high_load_graph_ms
+    HIGH_NORM = :high_normalization_ms
+    HIGH_ACTN = :high_action_request_ms
+    HIGH_FULL = :high_full_request_ms
   end
 end

--- a/app/models/concerns/qa_server/performance_history_data_keys.rb
+++ b/app/models/concerns/qa_server/performance_history_data_keys.rb
@@ -17,13 +17,22 @@ module QaServer
     BY_MONTH = :month
 
     LOW_LOAD = :low_load_ms
+    LOW_RETR = :low_retrieve_ms
+    LOW_GRPH = :low_load_graph_ms
     LOW_NORM = :low_normalization_ms
+    LOW_ACTN = :low_action_request_ms
     LOW_FULL = :low_full_request_ms
     AVG_LOAD = :avg_load_ms
+    AVG_RETR = :avg_retrieve_ms
+    AVG_GRPH = :avg_load_graph_ms
     AVG_NORM = :avg_normalization_ms
+    AVG_ACTN = :avg_action_request_ms
     AVG_FULL = :avg_full_request_ms
     HIGH_LOAD = :max_load_ms
+    HIGH_RETR = :max_retrieve_ms
+    HIGH_GRPH = :max_load_graph_ms
     HIGH_NORM = :max_normalization_ms
+    HIGH_ACTN = :max_action_request_ms
     HIGH_FULL = :max_full_request_ms
   end
 end

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -34,27 +34,27 @@ module QaServer
       #       { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }
       #     }
       #     { day:
-      #       { 0: { hour: '1400', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { hour: '1500', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { hour: '1600', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #       { 0: { hour: '1400', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         1: { hour: '1500', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         2: { hour: '1600', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
       #         ...,
-      #         23: { hour: 'NOW', load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #         23: { hour: 'NOW', retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
       #       }
       #     }
       #     { month:
-      #       { 0: { day: '07-15-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { day: '07-16-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { day: '07-17-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #       { 0: { day: '07-15-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         1: { day: '07-16-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         2: { day: '07-17-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
       #         ...,
-      #         29: { day: 'TODAY', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #         29: { day: 'TODAY', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
       #       }
       #     }
       #     { year:
-      #       { 0: { month: '09-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { month: '10-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { month: '11-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #       { 0: { month: '09-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         1: { month: '10-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #         2: { month: '11-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
       #         ...,
-      #         11: { month: '08-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #         11: { month: '08-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
       #       }
       #     }
       #     { AGROVOC_LD4L_CACHE: ... # same data for each authority  }
@@ -99,7 +99,7 @@ module QaServer
         # @param [String] auth_name - limit statistics to records for the given authority (default: all authorities)
         # @returns [Hash] performance statistics for the datatable during the expected time period
         # @example
-        #   { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }
+        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }
         def data_table_stats(auth_name)
           records = records_for_last_24_hours(auth_name) ||
                     records_for_last_30_days(auth_name) ||

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -30,34 +30,38 @@ module QaServer
       # @returns [Hash] performance statistics for the past 24 hours
       # @example
       #   { all_authorities:
-      #     { datatable_stats:
-      #       { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }
-      #     }
-      #     { day:
-      #       { 0: { hour: '1400', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { hour: '1500', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { hour: '1600', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         ...,
-      #         23: { hour: 'NOW', retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
-      #       }
-      #     }
-      #     { month:
-      #       { 0: { day: '07-15-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { day: '07-16-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { day: '07-17-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         ...,
-      #         29: { day: 'TODAY', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
-      #       }
-      #     }
-      #     { year:
-      #       { 0: { month: '09-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         1: { month: '10-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         2: { month: '11-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #         ...,
-      #         11: { month: '08-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
-      #       }
-      #     }
-      #     { AGROVOC_LD4L_CACHE: ... # same data for each authority  }
+      #     { search:
+      #       {
+      #         datatable_stats:
+      #           { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+      #             retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+      #             retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
+      #         day:
+      #           { 0: { hour: '1400', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { hour: '1500', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { hour: '1600', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             23: { hour: 'NOW', retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           },
+      #         month:
+      #           { 0: { day: '07-15-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { day: '07-16-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { day: '07-17-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             29: { day: 'TODAY', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           },
+      #         year:
+      #           { 0: { month: '09-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { month: '10-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { month: '11-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             11: { month: '08-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           }
+      #       },
+      #       fetch: { ... # same data as for search_stats }
+      #       all: { ... # same data as for search_stats }
+      #     },
+      #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
       #   }
       def performance_data(datatype: :datatable)
         return if datatype == :none
@@ -85,27 +89,33 @@ module QaServer
         end
 
         def data_for_authority(authority_name: nil, datatype:)
-          data = {}
-          data[FOR_DATATABLE] = data_table_stats(authority_name) if calculate_datatable?(datatype)
-          if calculate_graphdata?(datatype)
-            data[FOR_DAY] = graph_data_service_class.average_last_24_hours(authority_name)
-            data[FOR_MONTH] = graph_data_service_class.average_last_30_days(authority_name)
-            data[FOR_YEAR] = graph_data_service_class.average_last_12_months(authority_name)
+          action_data = {}
+          [:search, :fetch, :all_actions].each do |action|
+            data = {}
+            data[FOR_DATATABLE] = data_table_stats(authority_name, action) if calculate_datatable?(datatype)
+            if calculate_graphdata?(datatype)
+              data[FOR_DAY] = graph_data_service_class.average_last_24_hours(authority_name: authority_name, action: action)
+              data[FOR_MONTH] = graph_data_service_class.average_last_30_days(authority_name: authority_name, action: action)
+              data[FOR_YEAR] = graph_data_service_class.average_last_12_months(authority_name: authority_name, action: action)
+            end
+            action_data[action] = data
           end
-          data
+          action_data
         end
 
         # Get statistics for all available data.
         # @param [String] auth_name - limit statistics to records for the given authority (default: all authorities)
         # @returns [Hash] performance statistics for the datatable during the expected time period
         # @example
-        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }
-        def data_table_stats(auth_name)
+        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+        #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+        #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
+        def data_table_stats(auth_name, action)
           records = records_for_last_24_hours(auth_name) ||
                     records_for_last_30_days(auth_name) ||
                     records_for_last_12_months(auth_name) ||
                     all_records(auth_name)
-          stats_calculator_class.new(records).calculate_stats(avg: true, low: true, high: true)
+          stats_calculator_class.new(records, action: action).calculate_stats(avg: true, low: true, high: true)
         end
 
         def expected_time_period

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -16,15 +16,13 @@ module QaServer
       include QaServer::PerformanceHistoryDataKeys
 
       # Save a scenario result
-      # @param run_id [Integer] the run on which to gather statistics
-      # @param result [Hash] the scenario result to be saved
-      def save_result(dt_stamp:, authority:, action:, size_bytes:, load_time_ms:, normalization_time_ms:) # rubocop:disable Metrics/ParameterLists
-        create(dt_stamp: dt_stamp,
+      # @param authority [String] name of the authority
+      # @param action [Symbol] type of action being evaluated (e.g. :fetch, :search)
+      # @return ActveRecord::Base for the new performance history record
+      def create_record(authority:, action:)
+        create(dt_stamp: Time.now.getlocal,
                authority: authority,
-               action: action,
-               size_bytes: size_bytes,
-               load_time_ms: load_time_ms,
-               normalization_time_ms: normalization_time_ms)
+               action: action)
       end
 
       # Performance data for a day, a month, a year, and all time for each authority.

--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -12,7 +12,7 @@ module PrependedLinkedData::FindTerm
     begin
       full_results = super
       update_performance_history_record(full_results, start_time_s)
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       ph_record.destroy
       raise e
     end
@@ -47,9 +47,9 @@ module PrependedLinkedData::FindTerm
     # Temporary override to fix bug.  Remove when QA PR #273 is merged and a new release is cut
     def normalize_results
       normalize_start_dt = Time.now.utc
-  
+
       json = perform_normalization
-  
+
       normalize_end_dt = Time.now.utc
       @normalize_time_s = normalize_end_dt - normalize_start_dt
       @normalized_size = json.to_s.size if performance_data?

--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -3,50 +3,58 @@ module PrependedLinkedData::FindTerm
   # Override Qa::Authorities::LinkedData::FindTerm#find method
   # @return [Hash] single term results in requested format
   def find(id, language: nil, replacements: {}, subauth: nil, format: nil, jsonld: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
-    start_time_s = start_timing
+    start_time_s = Time.now.to_f
 
     saved_performance_data = performance_data
     performance_data = true
-    full_results = super
-    return full_results unless full_results.is_a?(Hash) && full_results.key?(:performance)
-    QaServer::PerformanceHistory.save_result(dt_stamp: Time.now.getlocal,
-                                             authority: authority_name,
-                                             action: 'fetch',
-                                             size_bytes: full_results[:performance][:fetched_bytes],
-                                             load_time_ms: (full_results[:performance][:fetch_time_s] * 1000),
-                                             normalization_time_ms: (full_results[:performance][:normalization_time_s] * 1000))
-
-    end_timing(start_time_s, full_results)
-    saved_performance_data ? full_results : full_results[:results]
-  end
-
-  # Temporary override to fix bug.  Remove when QA PR #273 is merged and a new release is cut
-  def normalize_results
-    normalize_start_dt = Time.now.utc
-
-    json = perform_normalization
-
-    normalize_end_dt = Time.now.utc
-    @normalize_time_s = normalize_end_dt - normalize_start_dt
-    @normalized_size = json.to_s.size if performance_data?
-    Rails.logger.info("Time to convert data to json: #{normalize_time_s}s")
-    json = append_performance_data(json) if performance_data?
-    json
+    ph_record = QaServer::PerformanceHistory.create_record(authority: authority_name, action: 'fetch')
+    @phid = ph_record.id
+    begin
+      full_results = super
+      update_performance_history_record(full_results, start_time_s)
+    rescue Exception => e
+      ph_record.destroy
+      raise e
+    end
+    saved_performance_data || !full_results.key?(:results) ? full_results : full_results[:results]
   end
 
   private
 
-    def start_timing
-      QaServer.config.performance_tracker.write 'fetch, ' # action
-      Time.now.to_f
+    def update_performance_history_record(full_results, start_time_s)
+      ph_record = QaServer::PerformanceHistory.find(@phid)
+      return ph_record.destroy unless full_results.is_a?(Hash) && full_results.key?(:performance)
+      ph_record.action_time_ms = (Time.now.to_f - start_time_s) * 1000
+      ph_record.size_bytes = full_results[:performance][:fetched_bytes]
+      ph_record.retrieve_plus_graph_load_time_ms = full_results[:performance][:fetch_time_s] * 1000
+      ph_record.normalization_time_ms = full_results[:performance][:normalization_time_s] * 1000
+      ph_record.save
     end
 
-    def end_timing(start_time_s, full_results)
-      end_time_s = Time.now.to_f
-      QaServer.config.performance_tracker.write "#{'%.6f' % (full_results[:performance][:normalization_time_s])}, " # normalization
-      QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # total
-      QaServer.config.performance_tracker.write "#{full_results[:performance][:fetched_bytes]}, " # data size
-      QaServer.config.performance_tracker.puts "#{authority_name}" # authority name
-      QaServer.config.performance_tracker.flush
+    # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
+    def load_graph(url:)
+      access_start_dt = Time.now.utc
+
+      url += "&phid=#{@phid}"
+      @full_graph = graph_service.load_graph(url: url)
+
+      access_end_dt = Time.now.utc
+      @access_time_s = access_end_dt - access_start_dt
+      @fetched_size = full_graph.triples.to_s.size if performance_data?
+      Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
+    end
+
+    # Temporary override to fix bug.  Remove when QA PR #273 is merged and a new release is cut
+    def normalize_results
+      normalize_start_dt = Time.now.utc
+  
+      json = perform_normalization
+  
+      normalize_end_dt = Time.now.utc
+      @normalize_time_s = normalize_end_dt - normalize_start_dt
+      @normalized_size = json.to_s.size if performance_data?
+      Rails.logger.info("Time to convert data to json: #{normalize_time_s}s")
+      json = append_performance_data(json) if performance_data?
+      json
     end
 end

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -3,36 +3,44 @@ module PrependedLinkedData::SearchQuery
   # Override Qa::Authorities::LinkedData::SearchQuery#search method
   # @return [String] json results for search query
   def search(query, language: nil, replacements: {}, subauth: nil, context: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
-    start_time_s = start_timing
+    start_time_s = Time.now.to_f
 
     saved_performance_data = performance_data
     performance_data = true
-    full_results = super
-    return full_results unless full_results.is_a?(Hash) && full_results.key?(:performance)
-    QaServer::PerformanceHistory.save_result(dt_stamp: Time.now.getlocal,
-                                             authority: authority_name,
-                                             action: 'search',
-                                             size_bytes: full_results[:performance][:fetched_bytes],
-                                             load_time_ms: (full_results[:performance][:fetch_time_s] * 1000),
-                                             normalization_time_ms: (full_results[:performance][:normalization_time_s] * 1000))
-
-    end_timing(start_time_s, full_results)
-    saved_performance_data ? full_results : full_results[:results]
+    ph_record = QaServer::PerformanceHistory.create_record(authority: authority_name, action: 'search')
+    @phid = ph_record.id
+    begin
+      full_results = super
+      update_performance_history_record(full_results, start_time_s)
+    rescue Exception => e
+      ph_record.destroy
+      raise e
+    end
+    saved_performance_data || !full_results.key?(:results) ? full_results : full_results[:results]
   end
 
   private
 
-    def start_timing
-      QaServer.config.performance_tracker.write 'search, ' # action
-      Time.now.to_f
+    def update_performance_history_record(full_results, start_time_s)
+      ph_record = QaServer::PerformanceHistory.find(@phid)
+      return ph_record.destroy unless full_results.is_a?(Hash) && full_results.key?(:performance)
+      ph_record.action_time_ms = (Time.now.to_f - start_time_s) * 1000
+      ph_record.size_bytes = full_results[:performance][:fetched_bytes]
+      ph_record.retrieve_plus_graph_load_time_ms = full_results[:performance][:fetch_time_s] * 1000
+      ph_record.normalization_time_ms = full_results[:performance][:normalization_time_s] * 1000
+      ph_record.save
     end
 
-    def end_timing(start_time_s, full_results)
-      end_time_s = Time.now.to_f
-      QaServer.config.performance_tracker.write "#{'%.6f' % (full_results[:performance][:normalization_time_s])}, " # normalization
-      QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # total
-      QaServer.config.performance_tracker.write "#{full_results[:performance][:fetched_bytes]}, " # data size
-      QaServer.config.performance_tracker.puts "#{authority_name}" # authority name
-      QaServer.config.performance_tracker.flush
+    # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
+    def load_graph(url:)
+      access_start_dt = Time.now.utc
+
+      url += "&phid=#{@phid}"
+      @full_graph = graph_service.load_graph(url: url)
+
+      access_end_dt = Time.now.utc
+      @access_time_s = access_end_dt - access_start_dt
+      @fetched_size = full_graph.triples.to_s.size if performance_data?
+      Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
     end
 end

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -12,7 +12,7 @@ module PrependedLinkedData::SearchQuery
     begin
       full_results = super
       update_performance_history_record(full_results, start_time_s)
-    rescue Exception => e
+    rescue Exception => e # rubocop:disable Lint/RescueException
       ph_record.destroy
       raise e
     end

--- a/app/prepends/prepended_rdf/rdf_graph.rb
+++ b/app/prepends/prepended_rdf/rdf_graph.rb
@@ -13,12 +13,14 @@ module PrependedRdf::RdfGraph
   # @return [void]
   def load(url, graph_name: nil, **options)
     raise TypeError.new("#{self} is immutable") if immutable?
-
+    phid, real_url = parse_phid(url)
+    ph_record = QaServer::PerformanceHistory.find(phid)
     start_time_s = Time.now.to_f
 
-    reader = RDF::Reader.open(url, {base_uri: url}.merge(options))
+    reader = RDF::Reader.open(real_url, {base_uri: real_url}.merge(options))
 
     end_time_s = Time.now.to_f
+    ph_record.retrieve_time_ms = (end_time_s - start_time_s) * 1000
     QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # read data
 
     start_time_s = Time.now.to_f
@@ -37,6 +39,17 @@ module PrependedRdf::RdfGraph
     end
 
     end_time_s = Time.now.to_f
+    ph_record.graph_load_time_ms = (end_time_s - start_time_s) * 1000
+    ph_record.save
     QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # load graph
   end
+
+  private
+
+    def parse_phid(url)
+      i = url.rindex('&phid=')
+      phid = url[(i + 6)..url.length]
+      adjusted_url = url[0..(i - 1)]
+      return phid, adjusted_url
+    end
 end

--- a/app/prepends/prepended_rdf/rdf_graph.rb
+++ b/app/prepends/prepended_rdf/rdf_graph.rb
@@ -11,17 +11,17 @@ module PrependedRdf::RdfGraph
   # @option options [RDF::Resource] :graph_name
   #   Set set graph name of each loaded statement
   # @return [void]
-  def load(url, graph_name: nil, **options)
-    raise TypeError.new("#{self} is immutable") if immutable?
+  def load(url, graph_name: nil, **options) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    raise TypeError, "#{self} is immutable" if immutable?
     phid, real_url = parse_phid(url)
     ph_record = QaServer::PerformanceHistory.find(phid)
     start_time_s = Time.now.to_f
 
-    reader = RDF::Reader.open(real_url, {base_uri: real_url}.merge(options))
+    reader = RDF::Reader.open(real_url, { base_uri: real_url }.merge(options))
 
     end_time_s = Time.now.to_f
     ph_record.retrieve_time_ms = (end_time_s - start_time_s) * 1000
-    QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # read data
+    QaServer.config.performance_tracker.write "#{format('%.6f', end_time_s - start_time_s)}, " # read data
 
     start_time_s = Time.now.to_f
 
@@ -41,7 +41,7 @@ module PrependedRdf::RdfGraph
     end_time_s = Time.now.to_f
     ph_record.graph_load_time_ms = (end_time_s - start_time_s) * 1000
     ph_record.save
-    QaServer.config.performance_tracker.write "#{'%.6f' % (end_time_s-start_time_s)}, " # load graph
+    QaServer.config.performance_tracker.write "#{format('%.6f', end_time_s - start_time_s)}, " # load graph
   end
 
   private
@@ -50,6 +50,6 @@ module PrependedRdf::RdfGraph
       i = url.rindex('&phid=')
       phid = url[(i + 6)..url.length]
       adjusted_url = url[0..(i - 1)]
-      return phid, adjusted_url
+      [phid, adjusted_url]
     end
 end

--- a/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
@@ -8,8 +8,12 @@ module QaServer::MonitorStatus
       authority_data[FOR_DATATABLE]
     end
 
-    def low_load(stats)
-      format_stat stats[LOW_LOAD]
+    def low_retrieve(stats)
+      format_stat stats[LOW_RETR]
+    end
+
+    def low_graph_load(stats)
+      format_stat stats[LOW_GRPH]
     end
 
     def low_normalization(stats)
@@ -17,11 +21,15 @@ module QaServer::MonitorStatus
     end
 
     def low_full_request(stats)
-      format_stat stats[LOW_FULL]
+      format_stat stats[LOW_ACTN]
     end
 
-    def high_load(stats)
-      format_stat stats[HIGH_LOAD]
+    def high_retrieve(stats)
+      format_stat stats[HIGH_RETR]
+    end
+
+    def high_graph_load(stats)
+      format_stat stats[HIGH_GRPH]
     end
 
     def high_normalization(stats)
@@ -29,11 +37,15 @@ module QaServer::MonitorStatus
     end
 
     def high_full_request(stats)
-      format_stat stats[HIGH_FULL]
+      format_stat stats[HIGH_ACTN]
     end
 
-    def avg_load(stats)
-      format_stat stats[AVG_LOAD]
+    def avg_retrieve(stats)
+      format_stat stats[AVG_RETR]
+    end
+
+    def avg_graph_load(stats)
+      format_stat stats[AVG_GRPH]
     end
 
     def avg_normalization(stats)
@@ -41,19 +53,19 @@ module QaServer::MonitorStatus
     end
 
     def avg_full_request(stats)
-      format_stat stats[AVG_FULL]
+      format_stat stats[AVG_ACTN]
     end
 
     def low_full_request_style(stats)
-      performance_style_class(stats, LOW_FULL)
+      performance_style_class(stats, LOW_ACTN)
     end
 
     def high_full_request_style(stats)
-      performance_style_class(stats, HIGH_FULL)
+      performance_style_class(stats, HIGH_ACTN)
     end
 
     def avg_full_request_style(stats)
-      performance_style_class(stats, AVG_FULL)
+      performance_style_class(stats, AVG_ACTN)
     end
 
     def performance_table_description

--- a/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
@@ -1,59 +1,72 @@
 # frozen_string_literal: true
 # This module provides access methods into the performance data hash.
 module QaServer::MonitorStatus
-  module PerformanceDatatableBehavior
+  module PerformanceDatatableBehavior # rubocop:disable Metrics/ModuleLength
     include QaServer::PerformanceHistoryDataKeys
 
-    def datatable_stats(authority_data)
-      authority_data[FOR_DATATABLE]
+    def datatable_search_stats(authority_data)
+      data_table_for(authority_data, SEARCH)
+    end
+
+    def datatable_fetch_stats(authority_data)
+      data_table_for(authority_data, FETCH)
+    end
+
+    def datatable_all_actions_stats(authority_data)
+      data_table_for(authority_data, ALL_ACTIONS)
     end
 
     def low_retrieve(stats)
-      format_stat stats[LOW_RETR]
+      format_stat stats, LOW_RETR
     end
 
     def low_graph_load(stats)
-      format_stat stats[LOW_GRPH]
+      format_stat stats, LOW_GRPH
     end
 
     def low_normalization(stats)
-      format_stat stats[LOW_NORM]
+      format_stat stats, LOW_NORM
     end
 
     def low_full_request(stats)
-      format_stat stats[LOW_ACTN]
+      format_stat stats, LOW_ACTN
     end
 
     def high_retrieve(stats)
-      format_stat stats[HIGH_RETR]
+      format_stat stats, HIGH_RETR
     end
 
     def high_graph_load(stats)
-      format_stat stats[HIGH_GRPH]
+      format_stat stats, HIGH_GRPH
     end
 
     def high_normalization(stats)
-      format_stat stats[HIGH_NORM]
+      format_stat stats, HIGH_NORM
     end
 
     def high_full_request(stats)
-      format_stat stats[HIGH_ACTN]
+      format_stat stats, HIGH_ACTN
     end
 
     def avg_retrieve(stats)
-      format_stat stats[AVG_RETR]
+      format_stat stats, AVG_RETR
     end
 
     def avg_graph_load(stats)
-      format_stat stats[AVG_GRPH]
+      format_stat stats, AVG_GRPH
     end
 
     def avg_normalization(stats)
-      format_stat stats[AVG_NORM]
+      format_stat stats, AVG_NORM
     end
 
     def avg_full_request(stats)
-      format_stat stats[AVG_ACTN]
+      format_stat stats, AVG_ACTN
+    end
+
+    def datatable_data_style(stats)
+      return "status-not-supported" if unsupported_action?(stats)
+      "status-neutral"
     end
 
     def low_full_request_style(stats)
@@ -87,12 +100,21 @@ module QaServer::MonitorStatus
         QaServer.config.performance_datatable_default_time_period
       end
 
-      def format_stat(stat)
-        return '' if stat.nil?
-        format("%0.1f", stat)
+      def data_table_for(authority_data, action)
+        authority_data[action][FOR_DATATABLE]
+      end
+
+      def unsupported_action?(stats)
+        stats[AVG_ACTN].nan?
+      end
+
+      def format_stat(stats, idx)
+        return '' if stats[idx].nil? || unsupported_action?(stats)
+        format("%0.1f", stats[idx])
       end
 
       def performance_style_class(stats, stat_key)
+        return "status-not-supported" if unsupported_action?(stats)
         return "status-bad" if max_threshold_exceeded(stats, stat_key)
         return "status-unknown" if desired_threshold_not_met(stats, stat_key)
         "status-good"

--- a/app/presenters/qa_server/monitor_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status_presenter.rb
@@ -25,14 +25,16 @@ module QaServer
 
     def_delegators :@performance_presenter, :performance_data, :performance_data?, :display_performance?, :display_performance_graph?,
                    :display_performance_datatable?, :performance_data_authority_name, :performance_for_day_graph, :performance_for_month_graph,
-                   :performance_for_year_graph, :datatable_stats, :low_retrieve, :low_graph_load, :low_normalization, :low_full_request,
-                   :high_retrieve, :high_graph_load, :high_normalization, :high_full_request, :avg_retrieve, :avg_graph_load,
-                   :avg_normalization, :avg_full_request, :low_load_style, :low_normalization_style, :low_full_request_style,
-                   :high_load_style, :high_normalization_style, :high_full_request_style, :avg_load_style, :avg_normalization_style,
-                   :avg_full_request_style, :performance_style_class, :high_threshold_exceeded, :low_threshold_not_met, :performance_graphs,
-                   :performance_graph, :performance_graph_authority, :performance_graph_label, :performance_default_graph_id,
-                   :performance_graph_id, :performance_graph_data_section_id, :performance_graph_data_section_base_id,
-                   :performance_data_section_class, :performance_day_graph_selected?, :performance_month_graph_selected?,
-                   :performance_year_graph_selected?, :performance_table_description
+                   :performance_for_year_graph, :datatable_search_stats, :datatable_fetch_stats, :datatable_all_actions_stats,
+                   :low_retrieve, :low_graph_load, :low_normalization, :low_full_request, :high_retrieve, :high_graph_load,
+                   :high_normalization, :high_full_request, :avg_retrieve, :avg_graph_load, :avg_normalization, :avg_full_request,
+                   :datatable_data_style, :low_load_style, :low_normalization_style, :low_full_request_style, :high_load_style,
+                   :high_normalization_style, :high_full_request_style, :avg_load_style, :avg_normalization_style, :avg_full_request_style,
+                   :performance_style_class, :high_threshold_exceeded, :low_threshold_not_met, :performance_graphs, :performance_graph,
+                   :performance_graph_authority, :performance_graph_label, :performance_default_graph_id, :performance_graph_id,
+                   :performance_graph_data_section_id, :performance_graph_data_section_base_id, :performance_data_section_class,
+                   :performance_day_graph?, :performance_month_graph?, :performance_year_graph?, :performance_all_actions_graph?,
+                   :performance_search_graph?, :performance_fetch_graph?, :performance_table_description, :performance_graph_time_period,
+                   :performance_graph_action
   end
 end

--- a/app/presenters/qa_server/monitor_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status_presenter.rb
@@ -25,12 +25,13 @@ module QaServer
 
     def_delegators :@performance_presenter, :performance_data, :performance_data?, :display_performance?, :display_performance_graph?,
                    :display_performance_datatable?, :performance_data_authority_name, :performance_for_day_graph, :performance_for_month_graph,
-                   :performance_for_year_graph, :datatable_stats, :low_load, :low_normalization, :low_full_request, :high_load,
-                   :high_normalization, :high_full_request, :avg_load, :avg_normalization, :avg_full_request, :low_load_style,
-                   :low_normalization_style, :low_full_request_style, :high_load_style, :high_normalization_style, :high_full_request_style,
-                   :avg_load_style, :avg_normalization_style, :avg_full_request_style, :performance_style_class, :high_threshold_exceeded,
-                   :low_threshold_not_met, :performance_graphs, :performance_graph, :performance_graph_authority, :performance_graph_label,
-                   :performance_default_graph_id, :performance_graph_id, :performance_graph_data_section_id, :performance_graph_data_section_base_id,
+                   :performance_for_year_graph, :datatable_stats, :low_retrieve, :low_graph_load, :low_normalization, :low_full_request,
+                   :high_retrieve, :high_graph_load, :high_normalization, :high_full_request, :avg_retrieve, :avg_graph_load,
+                   :avg_normalization, :avg_full_request, :low_load_style, :low_normalization_style, :low_full_request_style,
+                   :high_load_style, :high_normalization_style, :high_full_request_style, :avg_load_style, :avg_normalization_style,
+                   :avg_full_request_style, :performance_style_class, :high_threshold_exceeded, :low_threshold_not_met, :performance_graphs,
+                   :performance_graph, :performance_graph_authority, :performance_graph_label, :performance_default_graph_id,
+                   :performance_graph_id, :performance_graph_data_section_id, :performance_graph_data_section_base_id,
                    :performance_data_section_class, :performance_day_graph_selected?, :performance_month_graph_selected?,
                    :performance_year_graph_selected?, :performance_table_description
   end

--- a/app/services/qa_server/performance_calculator_service.rb
+++ b/app/services/qa_server/performance_calculator_service.rb
@@ -10,16 +10,16 @@ module QaServer
     # @param records [Array <Qa::PerformanceHistory>] set of records used to calculate the statistics
     def initialize(records, action: nil)
       @records = records
-      @action = action
+      @action = [:search, :fetch].include?(action) ? action : nil
       @stats = {}
     end
 
     # Calculate performance statistics for a set of PerformanceHistory records.  Min is at the 10th percentile.  Max is at the 90th percentile.
     # @return [Hash] hash of the statistics
     # @example
-    # { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
-    #   retrieve_min_ms: 12.3, graph_load_min_ms: 12.3, normalization_min_ms: 4.2, full_request_min_ms: 16.5,
-    #   retrieve_max_ms: 12.3, graph_load_max_ms: 12.3, normalization_max_ms: 4.2, full_request_max_ms: 16.5 }
+    #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+    #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+    #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
     def calculate_stats(avg: false, low: false, high: false, load: true, norm: true, full: true) # rubocop:disable Metrics/ParameterLists
       calculate_retrieve_stats(avg, low, high) if load
       calculate_graph_load_stats(avg, low, high) if load
@@ -32,26 +32,26 @@ module QaServer
 
       def calculate_retrieve_stats(avg, low, high)
         stats[AVG_RETR] = calculate_average(retrieve_times) if avg
-        stats[LOW_RETR] = calculate_10th_percentile(retrieve_times_sorted) if low
-        stats[HIGH_RETR] = calculate_90th_percentile(retrieve_times_sorted) if high
+        stats[LOW_RETR] = calculate_10th_percentile(retrieve_times) if low
+        stats[HIGH_RETR] = calculate_90th_percentile(retrieve_times) if high
       end
 
       def calculate_graph_load_stats(avg, low, high)
         stats[AVG_GRPH] = calculate_average(graph_load_times) if avg
-        stats[LOW_GRPH] = calculate_10th_percentile(graph_load_times_sorted) if low
-        stats[HIGH_GRPH] = calculate_90th_percentile(graph_load_times_sorted) if high
+        stats[LOW_GRPH] = calculate_10th_percentile(graph_load_times) if low
+        stats[HIGH_GRPH] = calculate_90th_percentile(graph_load_times) if high
       end
 
       def calculate_normalization_stats(avg, low, high)
         stats[AVG_NORM] = calculate_average(norm_times) if avg
-        stats[LOW_NORM] = calculate_10th_percentile(norm_times_sorted) if low
-        stats[HIGH_NORM] = calculate_90th_percentile(norm_times_sorted) if high
+        stats[LOW_NORM] = calculate_10th_percentile(norm_times) if low
+        stats[HIGH_NORM] = calculate_90th_percentile(norm_times) if high
       end
 
       def calculate_action_stats(avg, low, high)
         stats[AVG_ACTN] = calculate_average(action_times) if avg
-        stats[LOW_ACTN] = calculate_10th_percentile(action_times_sorted) if low
-        stats[HIGH_ACTN] = calculate_90th_percentile(action_times_sorted) if high
+        stats[LOW_ACTN] = calculate_10th_percentile(action_times) if low
+        stats[HIGH_ACTN] = calculate_90th_percentile(action_times) if high
       end
 
       def count
@@ -64,40 +64,25 @@ module QaServer
         percentile_count
       end
 
-      def retrieve_times
-        where_clause = action.nil? ? "" : {"action" => action}
-        @retrieve_times ||= records.where(where_clause).where.not(retrieve_time_ms: nil).pluck(:retrieve_time_ms)
+      def times(column)
+        where_clause = action.nil? ? "" : { "action" => action }
+        records.where(where_clause).where.not(column => nil).order(column).pluck(column)
       end
 
-      def retrieve_times_sorted
-        @retrieve_times_sorted ||= retrieve_times.sort
+      def retrieve_times
+        @retrieve_times ||= times(:retrieve_time_ms)
       end
 
       def graph_load_times
-        where_clause = action.nil? ? "" : {"action" => action}
-        @graph_load_times ||= records.where(where_clause).where.not(graph_load_time_ms: nil).pluck(:graph_load_time_ms)
-      end
-
-      def graph_load_times_sorted
-        @graph_load_times_sorted ||= graph_load_times.sort
+        @graph_load_times ||= times(:graph_load_time_ms)
       end
 
       def norm_times
-        where_clause = action.nil? ? "" : {"action" => action}
-        @norm_times ||= records.where(where_clause).where.not(normalization_time_ms: nil).pluck(:normalization_time_ms)
-      end
-
-      def norm_times_sorted
-        @norm_times_sorted ||= norm_times.sort
+        @norm_times ||= times(:normalization_time_ms)
       end
 
       def action_times
-        where_clause = action.nil? ? "" : {"action" => action}
-        @action_times ||= records.where(where_clause).where.not(action_time_ms: nil).pluck(:action_time_ms)
-      end
-
-      def action_times_sorted
-        @action_times_sorted ||= action_times.sort
+        @action_times ||= times(:action_time_ms)
       end
 
       def calculate_average(times)
@@ -106,16 +91,16 @@ module QaServer
         times.inject(0.0) { |sum, el| sum + el } / times.count
       end
 
-      def calculate_10th_percentile(sorted_times)
-        return 0 if sorted_times.count.zero?
-        return sorted_times[0] if sorted_times.count == 1
-        sorted_times[tenth_percentile_count(sorted_times) - 1]
+      def calculate_10th_percentile(times)
+        return 0 if times.count.zero?
+        return times[0] if times.count == 1
+        times[tenth_percentile_count(times) - 1]
       end
 
-      def calculate_90th_percentile(sorted_times)
-        return 0 if sorted_times.count.zero?
-        return sorted_times[0] if sorted_times.count == 1
-        sorted_times[sorted_times.count - tenth_percentile_count(sorted_times)]
+      def calculate_90th_percentile(times)
+        return 0 if times.count.zero?
+        return times[0] if times.count == 1
+        times[times.count - tenth_percentile_count(times)]
       end
   end
 end

--- a/app/services/qa_server/performance_calculator_service.rb
+++ b/app/services/qa_server/performance_calculator_service.rb
@@ -5,99 +5,117 @@ module QaServer
   class PerformanceCalculatorService
     include QaServer::PerformanceHistoryDataKeys
 
-    attr_reader :records
-    attr_reader :stats
+    attr_reader :records, :stats, :action
 
     # @param records [Array <Qa::PerformanceHistory>] set of records used to calculate the statistics
-    def initialize(records)
+    def initialize(records, action: nil)
       @records = records
+      @action = action
       @stats = {}
     end
 
     # Calculate performance statistics for a set of PerformanceHistory records.  Min is at the 10th percentile.  Max is at the 90th percentile.
     # @return [Hash] hash of the statistics
     # @example
-    # { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
-    #   load_min_ms: 12.3, normalization_min_ms: 4.2, full_request_min_ms: 16.5,
-    #   load_max_ms: 12.3, normalization_max_ms: 4.2, full_request_max_ms: 16.5 }
+    # { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+    #   retrieve_min_ms: 12.3, graph_load_min_ms: 12.3, normalization_min_ms: 4.2, full_request_min_ms: 16.5,
+    #   retrieve_max_ms: 12.3, graph_load_max_ms: 12.3, normalization_max_ms: 4.2, full_request_max_ms: 16.5 }
     def calculate_stats(avg: false, low: false, high: false, load: true, norm: true, full: true) # rubocop:disable Metrics/ParameterLists
-      calculate_load_stats(avg, low, high) if load
-      calculate_norm_stats(avg, low, high) if norm
-      calculate_full_stats(avg, low, high) if full
+      calculate_retrieve_stats(avg, low, high) if load
+      calculate_graph_load_stats(avg, low, high) if load
+      calculate_normalization_stats(avg, low, high) if norm
+      calculate_action_stats(avg, low, high) if full
       stats
     end
 
     private
 
-      def calculate_load_stats(avg, low, high)
-        stats[AVG_LOAD] = calculate_average(load_times) if avg
-        stats[LOW_LOAD] = calculate_10th_percentile(load_times_sorted) if low
-        stats[HIGH_LOAD] = calculate_90th_percentile(load_times_sorted) if high
+      def calculate_retrieve_stats(avg, low, high)
+        stats[AVG_RETR] = calculate_average(retrieve_times) if avg
+        stats[LOW_RETR] = calculate_10th_percentile(retrieve_times_sorted) if low
+        stats[HIGH_RETR] = calculate_90th_percentile(retrieve_times_sorted) if high
       end
 
-      def calculate_norm_stats(avg, low, high)
+      def calculate_graph_load_stats(avg, low, high)
+        stats[AVG_GRPH] = calculate_average(graph_load_times) if avg
+        stats[LOW_GRPH] = calculate_10th_percentile(graph_load_times_sorted) if low
+        stats[HIGH_GRPH] = calculate_90th_percentile(graph_load_times_sorted) if high
+      end
+
+      def calculate_normalization_stats(avg, low, high)
         stats[AVG_NORM] = calculate_average(norm_times) if avg
         stats[LOW_NORM] = calculate_10th_percentile(norm_times_sorted) if low
         stats[HIGH_NORM] = calculate_90th_percentile(norm_times_sorted) if high
       end
 
-      def calculate_full_stats(avg, low, high)
-        stats[AVG_FULL] = calculate_average(full_times) if avg
-        stats[LOW_FULL] = calculate_10th_percentile(full_times_sorted) if low
-        stats[HIGH_FULL] = calculate_90th_percentile(full_times_sorted) if high
+      def calculate_action_stats(avg, low, high)
+        stats[AVG_ACTN] = calculate_average(action_times) if avg
+        stats[LOW_ACTN] = calculate_10th_percentile(action_times_sorted) if low
+        stats[HIGH_ACTN] = calculate_90th_percentile(action_times_sorted) if high
       end
 
       def count
         @count ||= records.count
       end
 
-      def tenth_percentile_count
-        return @tenth_percentile_count if @tenth_percentile_count.present?
-        percentile_count = (count * 0.1).round
+      def tenth_percentile_count(times)
+        percentile_count = (times.count * 0.1).round
         percentile_count = 1 if percentile_count.zero? && count > 1
-        @tenth_percentile_count = percentile_count
+        percentile_count
       end
 
-      def load_times
-        @load_times ||= records.pluck(:load_time_ms).to_a
+      def retrieve_times
+        where_clause = action.nil? ? "" : {"action" => action}
+        @retrieve_times ||= records.where(where_clause).where.not(retrieve_time_ms: nil).pluck(:retrieve_time_ms)
       end
 
-      def load_times_sorted
-        @load_times_sorted ||= load_times.sort
+      def retrieve_times_sorted
+        @retrieve_times_sorted ||= retrieve_times.sort
+      end
+
+      def graph_load_times
+        where_clause = action.nil? ? "" : {"action" => action}
+        @graph_load_times ||= records.where(where_clause).where.not(graph_load_time_ms: nil).pluck(:graph_load_time_ms)
+      end
+
+      def graph_load_times_sorted
+        @graph_load_times_sorted ||= graph_load_times.sort
       end
 
       def norm_times
-        @norm_times ||= records.pluck(:normalization_time_ms).to_a
+        where_clause = action.nil? ? "" : {"action" => action}
+        @norm_times ||= records.where(where_clause).where.not(normalization_time_ms: nil).pluck(:normalization_time_ms)
       end
 
       def norm_times_sorted
         @norm_times_sorted ||= norm_times.sort
       end
 
-      def full_times
-        @full_times ||= (Vector.elements(load_times) + Vector.elements(norm_times)).to_a
+      def action_times
+        where_clause = action.nil? ? "" : {"action" => action}
+        @action_times ||= records.where(where_clause).where.not(action_time_ms: nil).pluck(:action_time_ms)
       end
 
-      def full_times_sorted
-        @full_times_sorted ||= full_times.sort
+      def action_times_sorted
+        @action_times_sorted ||= action_times.sort
       end
 
       def calculate_average(times)
         return 0 if count.zero?
         return times[0] if count == 1
-        times.inject(0.0) { |sum, el| sum + el } / count
+        times.inject(0.0) { |sum, el| sum + el } / times.count
       end
 
       def calculate_10th_percentile(sorted_times)
-        return 0 if count.zero?
-        return sorted_times[0] if count == 1
-        sorted_times[tenth_percentile_count - 1]
+        return 0 if sorted_times.count.zero?
+        return sorted_times[0] if sorted_times.count == 1
+        sorted_times[tenth_percentile_count(sorted_times) - 1]
       end
 
       def calculate_90th_percentile(sorted_times)
-        return 0 if count.zero?
-        return sorted_times[0] if count == 1
-        sorted_times[count - tenth_percentile_count]
+        return 0 if sorted_times.count.zero?
+        return sorted_times[0] if sorted_times.count == 1
+        sorted_times[sorted_times.count - tenth_percentile_count(sorted_times)]
       end
   end
 end

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -12,45 +12,50 @@ module QaServer
       # @param performance_data [Hash] hash of all performance data for all authorities
       # @see QaServer:PerformanceHistory
       def create_performance_graphs(performance_data:)
-        performance_data.each_key { |auth_name| create_graphs_for_authority(performance_data, auth_name.to_sym) }
+        performance_data.each_key do |auth_name|
+          create_graphs_for_authority(performance_data, auth_name.to_sym, :search)
+          create_graphs_for_authority(performance_data, auth_name.to_sym, :fetch)
+          create_graphs_for_authority(performance_data, auth_name.to_sym, :all_actions)
+        end
       end
 
       # @param authority_name [String] name of the authority
+      # @param action [Symbol] action performed by the request (e.g. :search, :fetch, :all_actions)
       # @param time_period [Symbol] time period for the graph (i.e. :day, :month, :year)
-      def performance_graph_file(authority_name: ALL_AUTH, time_period:)
-        File.join(graph_relative_path, graph_filename(authority_name, time_period))
+      def performance_graph_file(authority_name: ALL_AUTH, action:, time_period:)
+        File.join(graph_relative_path, graph_filename(authority_name, action, time_period))
       end
 
       private
 
-        def create_graphs_for_authority(performance_data, authority_name)
-          create_performance_for_day_graph(performance_data, authority_name)
-          create_performance_for_month_graph(performance_data, authority_name)
-          create_performance_for_year_graph(performance_data, authority_name)
+        def create_graphs_for_authority(performance_data, authority_name, action)
+          create_performance_for_day_graph(performance_data, authority_name, action)
+          create_performance_for_month_graph(performance_data, authority_name, action)
+          create_performance_for_year_graph(performance_data, authority_name, action)
         end
 
-        def create_performance_for_day_graph(performance_data, authority_name)
+        def create_performance_for_day_graph(performance_data, authority_name, action)
           auth_data = authority_performance_data(performance_data, authority_name)
           return unless auth_data
-          gruff_data = rework_performance_data_for_gruff(auth_data[FOR_DAY], BY_HOUR)
+          gruff_data = rework_performance_data_for_gruff(auth_data[action][FOR_DAY], BY_HOUR)
           create_gruff_graph(gruff_data,
-                             performance_for_day_graph_full_path(authority_name),
+                             performance_for_day_graph_full_path(authority_name, action),
                              I18n.t('qa_server.monitor_status.performance.x_axis_hour'))
         end
 
-        def create_performance_for_month_graph(performance_data, authority_name)
+        def create_performance_for_month_graph(performance_data, authority_name, action)
           auth_data = authority_performance_data(performance_data, authority_name)
-          gruff_data = rework_performance_data_for_gruff(auth_data[FOR_MONTH], BY_DAY)
+          gruff_data = rework_performance_data_for_gruff(auth_data[action][FOR_MONTH], BY_DAY)
           create_gruff_graph(gruff_data,
-                             performance_for_month_graph_full_path(authority_name),
+                             performance_for_month_graph_full_path(authority_name, action),
                              I18n.t('qa_server.monitor_status.performance.x_axis_day'))
         end
 
-        def create_performance_for_year_graph(performance_data, authority_name)
+        def create_performance_for_year_graph(performance_data, authority_name, action)
           auth_data = authority_performance_data(performance_data, authority_name)
-          gruff_data = rework_performance_data_for_gruff(auth_data[FOR_YEAR], BY_MONTH)
+          gruff_data = rework_performance_data_for_gruff(auth_data[action][FOR_YEAR], BY_MONTH)
           create_gruff_graph(gruff_data,
-                             performance_for_year_graph_full_path(authority_name),
+                             performance_for_year_graph_full_path(authority_name, action),
                              I18n.t('qa_server.monitor_status.performance.x_axis_month'))
         end
 
@@ -59,44 +64,47 @@ module QaServer
           data[auth_name]
         end
 
+        def performance_for_day_graph_full_path(authority_name, action)
+          graph_full_path(graph_filename(authority_name, action, :day))
+        end
+
+        def performance_for_month_graph_full_path(authority_name, action)
+          graph_full_path(graph_filename(authority_name, action, :month))
+        end
+
+        def performance_for_year_graph_full_path(authority_name, action)
+          graph_full_path(graph_filename(authority_name, action, :year))
+        end
+
+        def graph_filename(authority_name, action, time_period)
+          "performance_of_#{authority_name}_#{action}_for_#{time_period}_graph.png"
+        end
+
+        def rework_performance_data_for_gruff(performance_data, label_key)
+          labels = {}
+          retrieve_data = []
+          graph_load_data = []
+          normalization_data = []
+          performance_data.each do |i, data|
+            labels[i] = data[label_key]
+            retrieve_data << data[STATS][AVG_RETR]
+            graph_load_data << data[STATS][AVG_GRPH]
+            normalization_data << data[STATS][AVG_NORM]
+          end
+          [labels, normalization_data, graph_load_data, retrieve_data]
+        end
+
         def performance_graph_theme(g, x_axis_label)
           g.theme_pastel
           g.colors = [QaServer.config.performance_normalization_color,
-                      QaServer.config.performance_load_color]
+                      QaServer.config.performance_graph_load_color,
+                      QaServer.config.performance_retrieve_color]
           g.marker_font_size = 12
           g.x_axis_increment = 10
           g.x_axis_label = x_axis_label
           g.y_axis_label = I18n.t('qa_server.monitor_status.performance.y_axis_ms')
           g.minimum_value = 0
-          g.maximum_value = 2000
-        end
-
-        def performance_for_day_graph_full_path(authority_name)
-          graph_full_path(graph_filename(authority_name, :day))
-        end
-
-        def performance_for_month_graph_full_path(authority_name)
-          graph_full_path(graph_filename(authority_name, :month))
-        end
-
-        def performance_for_year_graph_full_path(authority_name)
-          graph_full_path(graph_filename(authority_name, :year))
-        end
-
-        def graph_filename(authority_name, time_period)
-          "performance_of_#{authority_name}_for_#{time_period}_graph.png"
-        end
-
-        def rework_performance_data_for_gruff(performance_data, label_key)
-          labels = {}
-          load_data = []
-          normalization_data = []
-          performance_data.each do |i, data|
-            labels[i] = data[label_key]
-            load_data << data[STATS][AVG_LOAD]
-            normalization_data << data[STATS][AVG_NORM]
-          end
-          [labels, normalization_data, load_data]
+          g.maximum_value = QaServer.config.performance_y_axis_max
         end
 
         def create_gruff_graph(performance_data, performance_graph_full_path, x_axis_label)
@@ -105,7 +113,8 @@ module QaServer
           g.title = ''
           g.labels = performance_data[0]
           g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[1])
-          g.data(I18n.t('qa_server.monitor_status.performance.load_time_ms'), performance_data[2])
+          g.data(I18n.t('qa_server.monitor_status.performance.graph_load_time_ms'), performance_data[2])
+          g.data(I18n.t('qa_server.monitor_status.performance.retrieve_time_ms'), performance_data[3])
           g.write performance_graph_full_path
         end
     end

--- a/app/views/qa_server/monitor_status/_performance.html.erb
+++ b/app/views/qa_server/monitor_status/_performance.html.erb
@@ -1,41 +1,72 @@
-  <% if @presenter.display_performance? && @presenter.performance_data? %>
+<% if @presenter.display_performance? && @presenter.performance_data? %>
     <div id="performance-data" class="status-section">
       <h3><%= t('qa_server.monitor_status.performance.title') %></h3>
 
-      <% if @presenter.display_performance_graph? %>
+  <% if @presenter.display_performance_graph? %>
       <script>
-        function switch_performance_view(base_id, time_period) {
-          document.getElementById(base_id+'-during-day').className = 'performance-data-section-hidden';
-          document.getElementById(base_id+'-during-month').className = 'performance-data-section-hidden';
-          document.getElementById(base_id+'-during-year').className = 'performance-data-section-hidden';
-          document.getElementById(base_id+'-during-'+time_period).className = 'performance-data-section-visible';
+        function switch_performance_view(base_id, time_period, action) {
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :all_actions, time_period: :day) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :all_actions, time_period: :month) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :all_actions, time_period: :year) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :search, time_period: :day) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :search, time_period: :month) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :search, time_period: :year) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :fetch, time_period: :day) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :fetch, time_period: :month) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :fetch, time_period: :year) %>').className = 'performance-data-section-hidden';
+          document.getElementById(base_id+'-'+action+'-during-'+time_period).className = 'performance-data-section-visible';
         }
       </script>
 
-      <% @presenter.performance_graphs.each do |graph_info| %>
+    <% @presenter.performance_graphs.each do |graph_info| %>
+      <% time_period = @presenter.performance_graph_time_period(graph_info) %>
+      <% action = @presenter.performance_graph_action(graph_info) %>
       <div id="<%= @presenter.performance_graph_data_section_id(graph_info) %>" class="<%= @presenter.performance_data_section_class(graph_info) %>">
-        <div class="right-menu-section">
+        <div class="performance-graph-menu-section">
           <h4><%= @presenter.performance_graph_authority(graph_info) %></h4>
-          <ul class="right-menu">
-            <% if @presenter.performance_day_graph_selected?(graph_info) %>
+          <ul class="time-period-menu">
+            <% if @presenter.performance_day_graph?(graph_info) %>
               <li class="selected"><%= t('qa_server.monitor_status.performance.menu_day') %></li>
             <% else %>
-              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'day')">
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'day', '<%= action %>')">
                 <%= t('qa_server.monitor_status.performance.menu_day') %>
               </li>
             <% end %>
-            <% if @presenter.performance_month_graph_selected?(graph_info) %>
+            <% if @presenter.performance_month_graph?(graph_info) %>
               <li class="selected"><%= t('qa_server.monitor_status.performance.menu_month') %></li>
             <% else %>
-              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'month')">
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'month', '<%= action %>')">
                 <%= t('qa_server.monitor_status.performance.menu_month') %>
               </li>
             <% end %>
-            <% if @presenter.performance_year_graph_selected?(graph_info) %>
+            <% if @presenter.performance_year_graph?(graph_info) %>
               <li class="selected"><%= t('qa_server.monitor_status.performance.menu_year') %></li>
             <% else %>
-              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'year')">
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', 'year', '<%= action %>')">
                 <%= t('qa_server.monitor_status.performance.menu_year') %>
+              </li>
+            <% end %>
+          </ul>
+          <ul class="action-menu">
+            <% if @presenter.performance_all_actions_graph?(graph_info) %>
+              <li class="selected"><%= t('qa_server.monitor_status.performance.menu_all_actions') %></li>
+            <% else %>
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', '<%= time_period %>', 'all_actions')">
+                <%= t('qa_server.monitor_status.performance.menu_all_actions') %>
+              </li>
+            <% end %>
+            <% if @presenter.performance_search_graph?(graph_info) %>
+              <li class="selected"><%= t('qa_server.monitor_status.performance.menu_search') %></li>
+            <% else %>
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', '<%= time_period %>', 'search')">
+                <%= t('qa_server.monitor_status.performance.menu_search') %>
+              </li>
+            <% end %>
+            <% if @presenter.performance_fetch_graph?(graph_info) %>
+              <li class="selected"><%= t('qa_server.monitor_status.performance.menu_fetch') %></li>
+            <% else %>
+              <li class="clickable" onClick="switch_performance_view('<%= @presenter.performance_graph_data_section_base_id(graph_info) %>', '<%= time_period %>', 'fetch')">
+                <%= t('qa_server.monitor_status.performance.menu_fetch') %>
               </li>
             <% end %>
           </ul>
@@ -46,51 +77,89 @@
           <%= image_tag(@presenter.performance_graph(graph_info), alt: @presenter.performance_graph_label(graph_info)) %>
         </div>
       </div>
-      <% end %>
-    </div>
     <% end %>
+    </div>
+  <% end %>
 
-    <% if @presenter.display_performance_datatable? %>
+  <% if @presenter.display_performance_datatable? %>
     <div id="performance-datatable-section">
       <h4><%= @presenter.performance_table_description %></h4>
       <table class="status">
         <tr>
           <th></th>
+          <th colspan="3" class="table_subheading"><%= t('qa_server.monitor_status.performance.search') %></th>
+          <th colspan="3" class="table_subheading"><%= t('qa_server.monitor_status.performance.fetch') %></th>
+          <th colspan="3" class="table_subheading"><%= t('qa_server.monitor_status.performance.all_actions') %></th>
+        </tr>
+        <tr>
+          <th></th>
+          <th><%= t('qa_server.monitor_status.performance.slowest_times') %></th>
+          <th><%= t('qa_server.monitor_status.performance.average_times') %></th>
+          <th><%= t('qa_server.monitor_status.performance.fastest_times') %></th>
+          <th><%= t('qa_server.monitor_status.performance.slowest_times') %></th>
+          <th><%= t('qa_server.monitor_status.performance.average_times') %></th>
+          <th><%= t('qa_server.monitor_status.performance.fastest_times') %></th>
           <th><%= t('qa_server.monitor_status.performance.slowest_times') %></th>
           <th><%= t('qa_server.monitor_status.performance.average_times') %></th>
           <th><%= t('qa_server.monitor_status.performance.fastest_times') %></th>
         </tr>
         <% @presenter.performance_data.each do |authority_name, data| %>
-          <% stats = @presenter.datatable_stats(data) %>
+          <% search_stats = @presenter.datatable_search_stats(data) %>
+          <% fetch_stats = @presenter.datatable_fetch_stats(data) %>
+          <% all_actions_stats = @presenter.datatable_all_actions_stats(data) %>
           <tr>
-            <td class="table_subheading" colspan="4"><%= authority_name %></td>
+            <td class="table_subheading" colspan="10"><%= authority_name %></td>
           </tr>
           <tr>
             <th><%= t('qa_server.monitor_status.performance.retrieve_times') %></th>
-            <td class="status-neutral"><%= @presenter.high_retrieve(stats) %></td>
-            <td class="status-neutral"><%= @presenter.avg_retrieve(stats) %></td>
-            <td class="status-neutral"><%= @presenter.low_retrieve(stats) %></td>
+            <td class="<%= @presenter.high_full_request_style(search_stats) %>"><%= @presenter.high_retrieve(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.avg_retrieve(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.low_retrieve(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.high_retrieve(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.avg_retrieve(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.low_retrieve(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.high_retrieve(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.avg_retrieve(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.low_retrieve(all_actions_stats) %></td>
           </tr>
           <tr>
             <th><%= t('qa_server.monitor_status.performance.graph_load_times') %></th>
-            <td class="status-neutral"><%= @presenter.high_graph_load(stats) %></td>
-            <td class="status-neutral"><%= @presenter.avg_graph_load(stats) %></td>
-            <td class="status-neutral"><%= @presenter.low_graph_load(stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.high_graph_load(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.avg_graph_load(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.low_graph_load(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.high_graph_load(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.avg_graph_load(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.low_graph_load(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.high_graph_load(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.avg_graph_load(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.low_graph_load(all_actions_stats) %></td>
           </tr>
           <tr>
             <th><%= t('qa_server.monitor_status.performance.normalization_times') %></th>
-            <td class="status-neutral"><%= @presenter.high_normalization(stats) %></td>
-            <td class="status-neutral"><%= @presenter.avg_normalization(stats) %></td>
-            <td class="status-neutral"><%= @presenter.low_normalization(stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.high_normalization(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.avg_normalization(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(search_stats) %>"><%= @presenter.low_normalization(search_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.high_normalization(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.avg_normalization(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(fetch_stats) %>"><%= @presenter.low_normalization(fetch_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.high_normalization(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.avg_normalization(all_actions_stats) %></td>
+            <td class="<%= @presenter.datatable_data_style(all_actions_stats) %>"><%= @presenter.low_normalization(all_actions_stats) %></td>
           </tr>
           <tr>
             <th><%= t('qa_server.monitor_status.performance.full_request_times') %></th>
-            <td class="<%= @presenter.high_full_request_style(stats) %>"><%= @presenter.high_full_request(stats) %></td>
-            <td class="<%= @presenter.avg_full_request_style(stats) %>"><%= @presenter.avg_full_request(stats) %></td>
-            <td class="<%= @presenter.low_full_request_style(stats) %>"><%= @presenter.low_full_request(stats) %></td>
+            <td class="<%= @presenter.high_full_request_style(search_stats) %>"><%= @presenter.high_full_request(search_stats) %></td>
+            <td class="<%= @presenter.avg_full_request_style(search_stats) %>"><%= @presenter.avg_full_request(search_stats) %></td>
+            <td class="<%= @presenter.low_full_request_style(search_stats) %>"><%= @presenter.low_full_request(search_stats) %></td>
+            <td class="<%= @presenter.high_full_request_style(fetch_stats) %>"><%= @presenter.high_full_request(fetch_stats) %></td>
+            <td class="<%= @presenter.avg_full_request_style(fetch_stats) %>"><%= @presenter.avg_full_request(fetch_stats) %></td>
+            <td class="<%= @presenter.low_full_request_style(fetch_stats) %>"><%= @presenter.low_full_request(fetch_stats) %></td>
+            <td class="<%= @presenter.high_full_request_style(all_actions_stats) %>"><%= @presenter.high_full_request(all_actions_stats) %></td>
+            <td class="<%= @presenter.avg_full_request_style(all_actions_stats) %>"><%= @presenter.avg_full_request(all_actions_stats) %></td>
+            <td class="<%= @presenter.low_full_request_style(all_actions_stats) %>"><%= @presenter.low_full_request(all_actions_stats) %></td>
           </tr>
         <% end %>
       </table>
     </div>
-    <% end %>
   <% end %>
+<% end %>

--- a/app/views/qa_server/monitor_status/_performance.html.erb
+++ b/app/views/qa_server/monitor_status/_performance.html.erb
@@ -66,10 +66,16 @@
             <td class="table_subheading" colspan="4"><%= authority_name %></td>
           </tr>
           <tr>
-            <th><%= t('qa_server.monitor_status.performance.load_times') %></th>
-            <td class="status-neutral"><%= @presenter.high_load(stats) %></td>
-            <td class="status-neutral"><%= @presenter.avg_load(stats) %></td>
-            <td class="status-neutral"><%= @presenter.low_load(stats) %></td>
+            <th><%= t('qa_server.monitor_status.performance.retrieve_times') %></th>
+            <td class="status-neutral"><%= @presenter.high_retrieve(stats) %></td>
+            <td class="status-neutral"><%= @presenter.avg_retrieve(stats) %></td>
+            <td class="status-neutral"><%= @presenter.low_retrieve(stats) %></td>
+          </tr>
+          <tr>
+            <th><%= t('qa_server.monitor_status.performance.graph_load_times') %></th>
+            <td class="status-neutral"><%= @presenter.high_graph_load(stats) %></td>
+            <td class="status-neutral"><%= @presenter.avg_graph_load(stats) %></td>
+            <td class="status-neutral"><%= @presenter.low_graph_load(stats) %></td>
           </tr>
           <tr>
             <th><%= t('qa_server.monitor_status.performance.normalization_times') %></th>

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -76,12 +76,19 @@ en:
         percent_failing: Percent Failing
       performance:
         title:           Performance Metrics
+        search:          Search Only
+        fetch:           Fetch Only
+        all_actions:     All Actions
         menu_day:        Day
         menu_month:      Month
         menu_year:       Year
-        load_time_ms:          Load Time (ms)
+        menu_all_actions: All Requests
+        menu_search:      Search
+        menu_fetch:       Fetch
+        graph_load_time_ms:    Graph Load Time (ms)
         normalization_time_ms: Normalization Time (ms)
-        full_request_time_ms:      Full Request Time (ms)
+        retrieve_time_ms:      Retrieve Time (ms)
+        full_request_time_ms:  Full Request Time (ms)
         x_axis_hour:     Hour
         x_axis_day:      Day
         x_axis_month:    Month

--- a/lib/generators/qa_server/templates/config/initializers/qa_server.rb
+++ b/lib/generators/qa_server/templates/config/initializers/qa_server.rb
@@ -12,14 +12,23 @@ QaServer.config do |config|
   # @param [Boolean] display performance graph when true
   # config.display_performance_graph = false
 
-  # Color of the graph line for load times in the performance graphs.
-  # @param [String] color RGB code
-  # @note The default colors for the load, normalization, and full request lines in the performance graph are accessible.
-  # config.performance_load_color = '#ABC3C9'
+  # Max time in milliseconds for y-axis in the performance graphs.
+  # @param [Integer] milliseconds
+  # config.performance_y_axis_max = 4000
 
-  # Color of the graph line for normalization times (The default colors for the performance graph are accessible.)
+  # Color of the graph line for retrieve times in the performance graphs.
   # @param [String] color RGB code
-  # @note The default colors for the load, normalization, and full request lines in the performance graph are accessible.
+  # @note The default colors for the retrieve, graph_load, load, normalization, and full request lines in the performance graph are accessible.
+  # config.performance_retrieve_color = '#ABC3C9'
+
+  # Color of the graph line for graph load times in the performance graphs.
+  # @param [String] color RGB code
+  # @note The default colors for the retrieve, graph_load, normalization, and full request lines in the performance graph are accessible.
+  # config.performance_graph_load_color = '#E8DCD3'
+
+  # Color of the graph line for normalization times in the performance graphs
+  # @param [String] color RGB code
+  # @note The default colors for the retrieve, graph_load, load, normalization, and full request lines in the performance graph are accessible.
   # config.performance_normalization_color = '#CCBE9F'
 
   # Performance graph default time period for all graphs.  All authorities will show the graph for this time period on page load.

--- a/lib/generators/qa_server/templates/db/migrate/20191007134527_update_performance_history_table.rb.erb
+++ b/lib/generators/qa_server/templates/db/migrate/20191007134527_update_performance_history_table.rb.erb
@@ -1,0 +1,19 @@
+class UpdatePerformanceHistoryTable < ActiveRecord::Migration<%= migration_version %>
+  def self.up
+    change_column :performance_history, :action, :integer
+    rename_column :performance_history, :load_time_ms, :retrieve_plus_graph_load_time_ms
+    add_column :performance_history, :retrieve_time_ms, :float, after: :size_bytes
+    add_column :performance_history, :graph_load_time_ms, :float, after: :retrieve_time_ms
+    add_column :performance_history, :action_time_ms, :float
+    add_index :performance_history, :action
+  end
+
+  def self.down
+    remove_index :performance_history, :action
+    remove_column :performance_history, :action_time_ms
+    remove_column :performance_history, :retrieve_time_ms
+    remove_column :performance_history, :graph_load_time_ms
+    rename_column :performance_history, :retrieve_plus_graph_load_time_ms, :load_time_ms
+    change_column :performance_history, :action, :string
+  end
+end

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -25,15 +25,31 @@ module QaServer
       @display_performance_graph = false
     end
 
-    # Color of the graph line for load times
-    # @param [String] color RGB code
-    attr_writer :performance_load_color
-    def performance_load_color
-      @performance_load_color ||= '#ABC3C9'
+    # Max time in milliseconds for y-axis in the performance graphs.
+    attr_writer :performance_y_axis_max
+    def performance_y_axis_max
+      @performance_y_axis_max ||= 4000
     end
 
-    # Color of the graph line for normalization times
+    # Color of the graph line for retrieve times in the performance graphs.
     # @param [String] color RGB code
+    # @note The default colors for the retrieve, graph_load, load, normalization, and full request lines in the performance graph are accessible.
+    attr_writer :performance_retrieve_color
+    def performance_retrieve_color
+      @performance_retrieve_color ||= '#ABC3C9'
+    end
+
+    # Color of the graph line for graph load times in the performance graphs.
+    # @param [String] color RGB code
+    # @note The default colors for the retrieve, graph_load, load, normalization, and full request lines in the performance graph are accessible.
+    attr_writer :performance_graph_load_color
+    def performance_graph_load_color
+      @performance_graph_load_color ||= '#E8DCD3'
+    end
+
+    # Color of the graph line for normalization times in the performance graphs
+    # @param [String] color RGB code
+    # @note The default colors for the retrieve, graph_load, load, normalization, and full request lines in the performance graph are accessible.
     attr_writer :performance_normalization_color
     def performance_normalization_color
       @performance_normalization_color ||= '#CCBE9F'


### PR DESCRIPTION
Performance graphs are created for all combinations of...
* authority:  each authority + all authorities
* time period: :day, :month, :year
* action: :all_actions, :search, :fetch

This produces 9 graphs per authority plus 9 more that include data from all authorities.

The performance data table splits details into combinations for...
* authority:  each authority + all authorities
* 10th percentile (fastest), average, 90th percentile (slowest)
* action: :all_actions, :search, :fetch
* task: :retrieve, :graph_load, :normalization, :full_action (labeled TOTAL)

where...
* :retrieve includes network costs + cache/authority processing for retrieving data from the cache or directly from an authority
* :graph_load includes the time to load the retrieved data into an RDF::Graph
* :normalization includes any time spent by QA to normalize the data including filtering out results, extracting extended context, and writing the normalized json
* :full_action is the length of time spent in the search method or find method.  There is a small amount of overhead for Rails routing and controller processing that is not included in this time.