### PR TITLE
update authorities with pagination; add RDA Registry and wikidata; split LCNAF

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/agrovoc_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/agrovoc_ld4l_cache.json
@@ -35,7 +35,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/agrovoc_batch.jsp?{?query}&{?maxRecords}&{?entity}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/agrovoc_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -58,6 +58,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/dbpedia_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/dbpedia_ld4l_cache.json
@@ -34,7 +34,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/dbpedia_name_batch.jsp?{?entity}&{?query}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/dbpedia_name_batch.jsp?{?entity}&{?query}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -57,6 +57,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/geonames_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/geonames_ld4l_cache.json
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/geonames_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/geonames_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -59,6 +59,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",
@@ -85,6 +92,7 @@
           "property_label_i18n": "qa.linked_data.authority.geonames_ld4l_cache.parent_adm1_label",
           "property_label_default": "Parent",
           "ldpath": "geonames:parentADM1 :: xsd:string",
+          "expansion_label_ldpath": "geonames:name ::xsd:string",
           "selectable": false,
           "drillable": false
         },
@@ -92,6 +100,7 @@
           "property_label_i18n": "qa.linked_data.authority.geonames_ld4l_cache.parent_adm2_label",
           "property_label_default": "Parent2",
           "ldpath": "geonames:parentADM2 :: xsd:string",
+          "expansion_label_ldpath": "geonames:name ::xsd:string",
           "selectable": false,
           "drillable": false
         },
@@ -99,6 +108,7 @@
           "property_label_i18n": "qa.linked_data.authority.geonames_ld4l_cache.parent_country_label",
           "property_label_default": "Parent Country",
           "ldpath": "geonames:parentCountry :: xsd:string",
+          "expansion_label_ldpath": "geonames:name ::xsd:string",
           "selectable": false,
           "drillable": false
         },

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/getty_aat_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/getty_aat_ld4l_cache.json
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&entity=Concept&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&entity=Concept&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -59,6 +59,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/getty_tgn_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/getty_tgn_ld4l_cache.json
@@ -37,7 +37,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&entity=Place&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&entity=Place&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -53,6 +53,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/getty_ulan_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/getty_ulan_ld4l_cache.json
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/getty_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -59,6 +59,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locdemographics_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locdemographics_ld4l_cache.json
@@ -1,6 +1,7 @@
 {
   "QA_CONFIG_VERSION": "2.1",
   "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
     "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
     "vivo":    "http://vivoweb.org/ontology/core#"
   },
@@ -120,7 +121,7 @@
         {
           "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.earlier_form",
           "property_label_default": "Earlier form",
-          "ldpath": "madsrdf:hasEarlierEstablishedForm/madsrdf:variantLabel :: xsd:string",
+          "ldpath": "madsrdf:hasEarlierEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
           "selectable": false,
           "drillable": false
         },

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_ld4l_cache.json
@@ -26,9 +26,9 @@
     },
     "term_id": "URI",
     "results": {
-      "id_ldpath":       "loc:lccn | madsrdf:code ::xsd:string",
-      "label_ldpath":    "skos:prefLabel ::xsd:string",
-      "altlabel_ldpath": "skos:altLabel ::xsd:string",
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "madsrdf:authoritativeLabel ::xsd:string",
+      "altlabel_ldpath": "madsrdf:hasVariant/madsrdf:variantLabel ::xsd:string",
       "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
     }
   },
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/loc_name_batch.jsp?{?query}&{?maxRecords}&{?entity}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/loc_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -62,6 +62,13 @@
         },
         {
           "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
           "variable": "lang",
           "property": "hydra:freetextQuery",
           "required": false,
@@ -74,8 +81,8 @@
       "subauth": "entity"
     },
     "results": {
-      "id_ldpath":    "loc:lccn | madsrdf:code ::xsd:string",
-      "label_ldpath": "skos:prefLabel ::xsd:string",
+      "id_ldpath":    "loc:lccn ::xsd:string",
+      "label_ldpath": "madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -83,81 +90,83 @@
         "dates": {
           "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
           "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
         }
       },
       "properties": [
         {
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.authoritative_label",
-          "property_label_default": "Authoritative Label",
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
           "ldpath": "madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
         {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Variant label",
           "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
-          "property_label_default": "Variant Label",
           "ldpath": "madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
           "selectable": false,
           "drillable": false
         },
         {
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
-          "property_label_default": "Field of Activity",
-          "ldpath": "(madsrdf:identifiesRWO/madsrdf:fieldOfActivity/rdfs:label) | (madsrdf:identifiesRWO/madsrdf:fieldOfActivity/madsrdf:authoritativeLabel) :: xsd:string",
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
           "selectable": false,
           "drillable": false
         },
         {
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.occupation",
-          "property_label_default": "Occupation",
-          "ldpath": "madsrdf:identifiesRWO/madsrdf:occupation/madsrdf:authoritativeLabel :: xsd:string",
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
           "selectable": false,
           "drillable": false
         },
         {
-          "group_id": "dates",
-          "property_label_default": "Birth: ",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
-          "ldpath": "madsrdf:identifiesRWO/madsrdf:birthDate/rdfs:label :: xsd:string",
+          "property_label_default": "Citation status",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_status",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-status :: xsd:string",
           "selectable": false,
           "drillable": false
         },
         {
-          "group_id": "dates",
-          "property_label_default": "Death: ",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_date",
-          "ldpath": "madsrdf:identifiesRWO/madsrdf:deathDate/rdfs:label :: xsd:string",
+          "property_label_default": "Earlier established form",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.ealier_established_form",
+          "ldpath": "madsrdf:hasEarlierEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
           "selectable": false,
-          "drillable": false
+          "drillable": false,
+          "subauth": ["conference"]
         },
         {
-          "group_id": "dates",
-          "property_label_default": "Start: ",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.activity_state_date",
-          "ldpath": "madsrdf:identifiesRWO/madsrdf:activityStartDate/rdfs:label :: xsd:string",
+          "property_label_default": "Later established form",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.later_established_form",
+          "ldpath": "madsrdf:hasLaterEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
           "selectable": false,
-          "drillable": false
+          "drillable": false,
+          "subauth": ["conference"]
         },
         {
-          "group_id": "dates",
-          "property_label_default": "End: ",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.activity_end_date",
-          "ldpath": "madsrdf:identifiesRWO/madsrdf:activityEndDate/rdfs:label :: xsd:string",
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "madsrdf:editorialNote :: xsd:string",
           "selectable": false,
           "drillable": false
         }
       ]
     },
     "subauthorities": {
-      "person":         "Person",
-      "personal_name":  "Person",
-      "organization":   "Organization",
-      "corporate_name": "Organization",
-      "place":          "Place",
-      "intangible":     "Intangible",
-      "geocoordinates": "GeoCoordinates",
-      "work":           "Work",
-      "title":          "Work"
+      "geographic":     "Geographic",
+      "conference":     "ConferenceName"
     }
   }
 }

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
@@ -1,0 +1,237 @@
+{
+  "QA_CONFIG_VERSION": "2.1",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath":    "rdfs:label ::xsd:string",
+      "altlabel_ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity"
+    },
+    "results": {
+      "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath": "rdfs:label ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
+        }
+      },
+      "properties": [
+        {
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdfs:label :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Descriptor",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Birth date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+          "ldpath": "madsrdf:birthDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "optional": true,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Death date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_date",
+          "ldpath": "madsrdf:deathDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Location",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.location",
+          "ldpath": "(madsrdf:associatedLocale/skos:prefLabel) | (madsrdf:associatedLocale/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["organization", "family"]
+        },
+        {
+          "property_label_default": "Affiliation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) | (madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Field of activity",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:fieldOfActivity/skos:prefLabel) | (madsrdf:fieldOfActivity/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Occupation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.occupation",
+          "ldpath": "(madsrdf:occupation/skos:prefLabel) | (madsrdf:occupation/rdfs:label) | (madsrdf:occupation/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Birth place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_place",
+          "ldpath": "(madsrdf:birthPlace/skos:prefLabel) | (madsrdf:birthPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Death place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_place",
+          "ldpath": "(madsrdf:deathPlace/skos:prefLabel) | (madsrdf:deathPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "property_label_default": "VIAF match",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.viaf_match",
+          "ldpath": "^madsrdf:identifiesRWO/skos:exactMatch :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Variant label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:editorialNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "person":         "Person",
+      "organization":   "Organization",
+      "family":         "Family"
+    }
+  }
+}

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locperformance_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locperformance_ld4l_cache.json
@@ -27,7 +27,7 @@
     "term_id": "URI",
     "results": {
       "id_ldpath":       "loc:lccn ::xsd:string",
-      "label_ldpath":    "madsrdf:authoritativeLabel ::xsd:string",
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
       "altlabel_ldpath": "skos:altLabel ::xsd:string",
       "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
     }
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/loc_performance_batch.jsp?{?query}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/loc_performance_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -55,6 +55,13 @@
         },
         {
           "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
           "variable": "lang",
           "property": "hydra:freetextQuery",
           "required": false,
@@ -66,8 +73,73 @@
       "query":   "query"
     },
     "results": {
-      "label_ldpath": "madsrdf:authoritativeLabel ::xsd:string",
+      "label_ldpath": "skos:prefLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.alt_label",
+          "property_label_default": "Alternative Label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_note",
+          "property_label_default": "Citation note",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_source",
+          "property_label_default": "Citation source",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_status",
+          "property_label_default": "Citation status",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        }
+      ]
     }
   }
 }

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/mesh_nlm_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/mesh_nlm_ld4l_cache.json
@@ -32,7 +32,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/mesh_batch.jsp?{?query}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/mesh_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -48,6 +48,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/nalt_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/nalt_ld4l_cache.json
@@ -35,7 +35,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/nalt_batch.jsp?{?query}&{?maxRecords}&{?entity}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/nalt_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -58,6 +58,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_ld4l_cache.json
@@ -35,7 +35,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/fast_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/fast_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -58,6 +58,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/rda_registry_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/rda_registry_ld4l_cache.json
@@ -1,0 +1,193 @@
+{
+  "QA_CONFIG_VERSION": "2.1",
+  "prefixes": {
+    "vivo": "http://vivoweb.org/ontology/core#"
+  },
+  "term": {},
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/rda_batch.jsp?{?entity}&{?query}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity"
+    },
+    "results": {
+      "label_ldpath": "skos:prefLabel ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.authoritative_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.alternative_label",
+          "property_label_default": "Alternative label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.related",
+          "property_label_default": "Related",
+          "ldpath": "skos:related/skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.definition",
+          "property_label_default": "Definition",
+          "ldpath": "skos:definition :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.scope_note",
+          "property_label_default": "Scope note",
+          "ldpath": "skos:scopeNote :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.rda_carrier_type_ld4l_cache.status",
+          "property_label_default": "Status",
+          "ldpath": "skos:status/skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "aspect_ratio":        "AspectRatio",
+      "collective_title":    "CollTitle",
+      "illustrative_content": "IllusContent",
+      "mode_of_issuance":    "ModeIssue",
+      "form_of_musical_notation": "MusNotation",
+      "carrier_extent_unit": "RDACarrierEU",
+      "carrier_type":        "RDACarrierType",
+      "cartographic_data_type": "RDACartoDT",
+      "colour_content":      "RDAColourContent",
+      "content_type":        "RDAContentType",
+      "generation":          "RDAGeneration",
+      "material":            "RDAMaterial",
+      "media_type":          "RDAMediaType",
+      "polarity":            "RDAPolarity",
+      "recording_sources":   "RDARecordingSources",
+      "reduction_ratio":     "RDAReductionRatio",
+      "regional_encoding":   "RDARegionalEncoding",
+      "terms":               "RDATerms",
+      "type_of_binding":     "RDATypeOfBinding",
+      "base_material":       "RDAbaseMaterial",
+      "production_method":   "RDAproductionMethod",
+      "form_of_tactile_notation": "TacNotation",
+      "bibliographic_format": "bookFormat",
+      "broadcast_standard":  "broadcastStand",
+      "config_playback_channels": "configPlayback",
+      "file_type":           "fileType",
+      "font_size":           "fontSize",
+      "format_of_notated_music": "formatNoteMus",
+      "frequency":           "frequency",
+      "gender":              "gender",
+      "groove_pitch":        "groovePitch",
+      "groove_width":        "grooveWidth",
+      "layout":              "layout",
+      "form_of_notated_movement": "noteMove",
+      "presentation_format": "presFormat",
+      "prod_tactile":        "prodTactile",
+      "recording_medium":    "recMedium",
+      "rofch":               "rofch",
+      "rofchrda":            "rofchrda",
+      "rofem":               "rofem",
+      "rofer":               "rofer",
+      "rofet":               "rofet",
+      "roffgrda":            "roffgrda",
+      "rofhf":               "rofhf",
+      "rofid":               "rofid",
+      "rofim":               "rofim",
+      "rofin":               "rofin",
+      "rofit":               "rofit",
+      "rofitrda":            "rofitrda",
+      "rofrm":               "rofrm",
+      "rofrr":               "rofrr",
+      "rofrt":               "rofrt",
+      "rofsf":               "rofsf",
+      "rofsfrda":            "rofsfrda",
+      "rofsm":               "rofsm",
+      "scale_designation":   "scale",
+      "sound_content":       "soundCont",
+      "special_playback":    "specPlayback",
+      "status_of_identification": "statIdentification",
+      "track_config":        "trackConfig",
+      "type_of_recording":   "typeRec",
+      "video_format":        "videoFormat"
+    }
+  }
+}

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -4,28 +4,13 @@ authority:
   context: true
 search:
   -
-    query: 'mark twain'
-  -
-    query: 'mark twain'
-    subauth: person
-  -
-    query: 'Twain, Mark, 1835-1910'
-    subauth: person
-  -
-    query: 'mark twain'
-    subauth: organization
+    query: Cayuga
   -
     query: Cayuga
-    subauth: place
+    subauth: geographic
   -
-    query: Cayuga
-    subauth: intangible
-  -
-    query: Cayuga
-    subauth: geocoordinates
-  -
-    query: 'mark twain'
-    subauth: work
+    query: ALA
+    subauth: conference
 term:
   -
     identifier: 'http://id.loc.gov/authorities/names/n92016188'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -1,0 +1,27 @@
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  -
+    query: 'mark twain'
+  -
+    query: 'Twain, Mark, 1835-1910'
+    subauth: person
+  -
+    query: 'mark twain'
+    subauth: organization
+  -
+    query: 'twain'
+    subauth: family
+  -
+    query: 'Twain, Mark, 1835-1910'
+    subauth: person
+    position: 1
+    subject_uri: "http://id.loc.gov/rwo/agents/n79021164"
+    replacements:
+      maxRecords: '10'
+      context: true
+term:
+  -
+    identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locperformance_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locperformance_ld4l_cache_validation.yml
@@ -1,6 +1,7 @@
 ---
 authority:
   service: ld4l_cache
+  context: true
 search:
   -
     query: band

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
@@ -1,0 +1,255 @@
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  -
+    query: full
+    subauth: aspect_ratio
+    result_size: 130
+  -
+    query: essays
+    subauth: collective_title
+    result_size: 130
+  -
+    query: graph
+    subauth: illustrative_content
+    result_size: 130
+  -
+    query: single
+    subauth: mode_of_issuance
+    result_size: 130
+  -
+    query: letter
+    subauth: form_of_musical_notation
+    result_size: 130
+  -
+    query: case
+    subauth: carrier_extent_unit
+    result_size: 130
+  -
+    query: audio
+    subauth: carrier_type
+    result_size: 130
+  -
+    query: point
+    subauth: cartographic_data_type
+    result_size: 130
+  -
+    query: monochrome
+    subauth: colour_content
+    result_size: 130
+  -
+    query: image
+    subauth: content_type
+    result_size: 130
+  -
+    query: disc
+    subauth: generation
+    result_size: 130
+  -
+    query: paper
+    subauth: material
+    result_size: 130
+  -
+    query: audio
+    subauth: media_type
+    result_size: 130
+  -
+    query: positive
+    subauth: polarity
+    result_size: 130
+  -
+    query: title
+    subauth: recording_sources
+    result_size: 130
+  -
+    query: high
+    subauth: reduction_ratio
+    result_size: 130
+  -
+    query: video
+    subauth: regional_encoding
+    result_size: 130
+  -
+    query: audio
+    subauth: terms
+    result_size: 130
+  -
+    query: ring
+    subauth: type_of_binding
+    result_size: 130
+# Deprecated
+#   -
+#    query: ALA
+#    subauth: base_material
+#    result_size: 130
+  -
+    query: print
+    subauth: production_method
+    result_size: 130
+  -
+    query: braille
+    subauth: form_of_tactile_notation
+    result_size: 130
+  -
+    query: folio
+    subauth: bibliographic_format
+    result_size: 130
+  -
+    query: PAL
+    subauth: broadcast_standard
+    result_size: 130
+  -
+    query: mono
+    subauth: config_playback_channels
+    result_size: 130
+  -
+    query: audio
+    subauth: file_type
+    result_size: 130
+  -
+    query: large
+    subauth: font_size
+    result_size: 130
+  -
+    query: choir
+    subauth: format_of_notated_music
+    result_size: 130
+  -
+    query: times
+    subauth: frequency
+    result_size: 130
+  -
+    query: male
+    subauth: gender
+    result_size: 120
+  -
+    query: fine
+    subauth: groove_pitch
+    result_size: 130
+  -
+    query: coarse
+    subauth: groove_width
+    result_size: 130
+  -
+    query: single
+    subauth: layout
+    result_size: 130
+  -
+    query: game
+    subauth: form_of_notated_movement
+    result_size: 130
+  -
+    query: standard
+    subauth: presentation_format
+    result_size: 130
+# Deprecated
+#   -
+#    query: ALA
+#    subauth: prod_tactile
+#    result_size: 130
+  -
+    query: optical
+    subauth: recording_medium
+    result_size: 130
+  -
+    query: music
+    subauth: rofch
+    result_size: 120
+#   -
+#    query: ALA
+#    subauth: rofchrda
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofem
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofer
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofet
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: roffgrda
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofhf
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofid
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofim
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofin
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofit
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofitrda
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofrm
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofrr
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofrt
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofsf
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofsfrda
+#    result_size: 130
+#   -
+#    query: ALA
+#    subauth: rofsm
+#    result_size: 130
+  -
+    query: scale
+    subauth: scale_designation
+    result_size: 130
+  -
+    query: sound
+    subauth: sound_content
+    result_size: 130
+  -
+    query: dolby
+    subauth: special_playback
+    result_size: 130
+  -
+    query: preliminary
+    subauth: status_of_identification
+    result_size: 130
+  -
+    query: edge
+    subauth: track_config
+    result_size: 130
+  -
+    query: digital
+    subauth: type_of_recording
+    result_size: 120
+  -
+    query: laser
+    subauth: video_format
+    result_size: 130

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/wikidata_direct_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/wikidata_direct_validation.yml
@@ -1,0 +1,6 @@
+---
+authority:
+  service: direct
+term:
+  -
+    identifier: http://www.wikidata.org/entity/Q8495

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/wikidata_direct.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/wikidata_direct.json
@@ -1,0 +1,32 @@
+{
+  "QA_CONFIG_VERSION": "2.1",
+  "prefixes": {
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "{term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   false
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "language": ["en"],
+    "results": {
+      "label_ldpath":    "skos:prefLabel",
+      "altlabel_ldpath": "skos:altLabel"
+    }
+  },
+  "search": {}
+}


### PR DESCRIPTION
* adds pagination start_record parameter for LD4P cached data
* adds RDA Registry authority
* splits LCNAF into 2 authorities for LD4P cached data focused locnames and real world object focused locnames_rwo
* adds wikidata authority - NOTE: The first pass on fetching through this authority is non-performant.