### PR TITLE
prep for release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.0.4 (2019-11-14)
+### 4.0.0 (2019-11-14)
 
 * prepends for find and query updated to process request_header parameter
 

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '3.0.4'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
NOTE: Was going to release as 3.0.4, but the change to add request_header forced a parameter change in the prepends for find and query.  This seemed to warrant a major release as the public signature has changed.