### PR TITLE
prep release of 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.0.2 (2019-12-3)
+
+* bug fix - move individual params into request header to avoid lost subauths during testing
+
 ### 5.0.1 (2019-12-3)
 
 * bug fix - force qa to not exclued performance header when find term returns jsonld

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end


### PR DESCRIPTION
* bug fix - move individual params into request header to avoid lost subauths during testing
