### PR TITLE
allow suppression of performance data gathering

### DIFF
--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -3,6 +3,8 @@ module PrependedLinkedData::FindTerm
   # Override Qa::Authorities::LinkedData::FindTerm#find method
   # @return [Hash] single term results in requested format
   def find(id, request_header: {}, language: nil, replacements: {}, subauth: nil, format: nil, performance_data: false) # rubocop:disable Metrics/ParameterLists
+    return super if config.suppress_performance_gathering
+
     start_time_s = Time.now.to_f
     request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, format: format, performance_data: performance_data) if request_header.empty?
     saved_performance_data = performance_data || request_header[:performance_data]

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -3,6 +3,8 @@ module PrependedLinkedData::SearchQuery
   # Override Qa::Authorities::LinkedData::SearchQuery#search method
   # @return [String] json results for search query
   def search(query, request_header: {}, language: nil, replacements: {}, subauth: nil, context: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
+    return super if config.suppress_performance_gathering
+
     start_time_s = Time.now.to_f
     request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, context: context, performance_data: performance_data) if request_header.empty?
     saved_performance_data = performance_data || request_header[:performance_data]

--- a/lib/generators/qa_server/templates/config/initializers/qa_server.rb
+++ b/lib/generators/qa_server/templates/config/initializers/qa_server.rb
@@ -56,4 +56,9 @@ QaServer.config do |config|
   # config.navmenu_extra_leftitems = [
   #   { label: 'Your Menu Item Label', url: 'http://your.menu.item/url' }
   # ]
+
+  # Performance data is gathered on every incoming query.  If load is high, this can have a negative performance
+  # impact and may need to be suppressed.  Performance stats will not be gathered when this config is true.
+  # @param [Boolean] do not gather performance data when true (defaults to false for backward compatibitily)
+  # config.suppress_performance_gathering = false
 end

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -114,5 +114,12 @@ module QaServer
         f.puts('action, http request, load graph, normalization, TOTAL, data size, authority')
       end
     end
+
+    # Performance data is gathered on every incoming query.  If load is high, this can have a negative performance
+    # impact and may need to be suppressed.  Performance stats will not be gathered when this config is true.
+    # @param [Boolean] do not gather performance data when true (defaults to false for backward compatibitily)
+    def suppress_performance_gathering
+      @suppress_performance_gathering ||= false
+    end
   end
 end


### PR DESCRIPTION
Performance data is gathered on every request.  During peak access times, this can become a performance drain itself.  This allows performance data gathering to be stopped when needed.