### PR TITLE
prep for release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 5.2.0 (2019-12-10)
+
+* cache performance data saving once a day when monitoring runs
+* set monitoring to expire at 3am ET by default (configurable)
+* setup travis-ci to run
+
 ### 5.1.0 (2019-12-10)
 
 * allow suppression of performance data gathering

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '5.1.0'
+  VERSION = '5.2.0'
 end


### PR DESCRIPTION
NOTE: Two commits were made without a PR.  They comprise the 5.2.0 release.

Look for commits with title…
* set monitoring to expire nightly at 3am ET by default
* save performance data once a day when running monitoring tests

Also includes changes from PRs...
* setup travis-ci to run