### PR TITLE
add defaults to configuration initializer

### DIFF
--- a/lib/generators/qa_server/templates/config/initializers/qa_server.rb
+++ b/lib/generators/qa_server/templates/config/initializers/qa_server.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 QaServer.config do |config|
+  # Preferred time zone for reporting historical data and performance data
+  # @param [String] time zone name
+  # @see https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html for possible values of TimeZone names
+  # config.preferred_time_zone_name = 'Eastern Time (US & Canada)'
+
+  # Preferred hour to run monitoring tests
+  # @param [Integer] count of hours from midnight (0-23 with 0=midnight)
+  # @example
+  #   For preferred_time_zone_name of 'Eastern Time (US & Canada)', use 3 for slow down at midnight PT/3am ET
+  #   For preferred_time_zone_name of 'Pacific Time (US & Canada)', use 0 for slow down at midnight PT/3am ET
+  # config.hour_offset_to_run_monitoring_tests = 3
+
   # Displays a graph of historical test data when true
   # @param [Boolean] display history graph when true
   # config.display_historical_graph = false

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -12,8 +12,8 @@ module QaServer
     # Preferred hour to run monitoring tests
     # @param [Integer] count of hours from midnight (0-23 with 0=midnight)
     # @example
-    #   For preferred_time_zone_name of ET, use 3 for slow down at midnight PT/3am ET
-    #   For preferred_time_zone_name of PT, use 0 for slow down at midnight PT/3am ET
+    #   For preferred_time_zone_name of 'Eastern Time (US & Canada)', use 3 for slow down at midnight PT/3am ET
+    #   For preferred_time_zone_name of 'Pacific Time (US & Canada)', use 0 for slow down at midnight PT/3am ET
     attr_writer :hour_offset_to_run_monitoring_tests
     def hour_offset_to_run_monitoring_tests
       @hour_offset_to_run_monitoring_tests ||= 3


### PR DESCRIPTION
Missed adding defaults to qa_server.rb initializer in generator templates.  Added defaults for preferred_time_zone_name and hour_offset_to_run_monitoring_tests configs.