### PR TITLE
Revert logging of graph load failures - Moved logging to QA

### DIFF
--- a/app/prepends/prepended_services/graph_service.rb
+++ b/app/prepends/prepended_services/graph_service.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-module PrependedServices::GraphService
-  # Override Qa::LinkedData::GraphService#process_error method
-  def process_error(e, url)
-    Rails.logger.warn("******** RDF::Graph#load failure: exception=#{e.inspect}")
-    super
-  end
-end

--- a/lib/generators/qa_server/config_generator.rb
+++ b/lib/generators/qa_server/config_generator.rb
@@ -40,7 +40,6 @@ class QaServer::ConfigGenerator < Rails::Generators::Base
       "\n      config.to_prepare do"\
       "\n        Qa::Authorities::LinkedData::FindTerm.prepend PrependedLinkedData::FindTerm"\
       "\n        Qa::Authorities::LinkedData::SearchQuery.prepend PrependedLinkedData::SearchQuery"\
-      "\n        Qa::LinkedData::GraphService.prepend PrependedServices::GraphService"\
       "\n        RDF::Graph.prepend PrependedRdf::RdfGraph"\
       "\n      end\n"
     end


### PR DESCRIPTION
This prepend is no longer needed.  The logging happening in the original commit has been moved to QA release 5.3.0.