### PR TITLE
prep release 5.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   bundler: true
 
 before_install:
-#  - gem update --system
   - gem update bundler
   - gem install bundler
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.3.0 (2019-12-19)
+
+* optionally log browser and platform user agent info
+* update to qa 5.3
+  * add a request id to the search and find request headers
+  * log exception for graph load failures
+  * optionally include IP info at start of search/find linked data requests
+
 ### 5.2.1 (2019-12-13)
 
 * fix - add defaults to the initializer generator template for new configs

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '5.2.1'
+  VERSION = '5.3.0'
 end


### PR DESCRIPTION
* optionally log browser and platform user agent info
* update to qa 5.3
  * add a request id to the search and find request headers
  * log exception for graph load failures
  * optionally include IP info at start of search/find linked data requests