### PR TITLE
prep for release 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.5.0 (2020-01-10)
+
+* use caching with expiry for monitor status page
+
 ### 5.4.0 (2020-01-07)
 
 * adds config hour_offset_to_expire_cache

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '5.4.0'
+  VERSION = '5.5.0'
 end


### PR DESCRIPTION
Use caching with expiry for monitor status page.

Cached…
* summary table data for latest run
* failures for latest run, if any
* authority connection history
* performance graph data
* performance data table data

Allows forced refresh in the same way as done previously.