### PR TITLE
run monitoring tests in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Only required if you want to generate status charts.  Generated charts will be s
 `app/assets/images/qa_server/charts` directory.  By default status is displayed in a table.
 
 1. [ImageMagick](http://www.imagemagick.org/)
+2. job queue processor of your choice
 
 ### Installation Instructions
 
@@ -58,6 +59,57 @@ $ rake db:migrate
 ```
 
 If upgrading instead of installing, see the Release notes for steps you may need to take manually since you won't be running the installer.
+
+#### Setting up monitoring
+
+Monitoring runs once a day as a background job.  
+
+##### Configuring cache expiration
+
+There are several configurations that control when the monitoring job will execute.
+
+```
+    # Preferred time zone for reporting historical data and performance data
+    # @param [String] time zone name
+    # @see https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html for possible values of TimeZone names
+    attr_writer :preferred_time_zone_name
+    def preferred_time_zone_name
+      @preferred_time_zone_name ||= 'Eastern Time (US & Canada)'
+    end
+
+    # Set preferred hour to expire caches related to slow running calculations (e.g. monitoring tests, performance data)
+    # @param [Integer] count of hours after midnight (0-23 with 0=midnight)
+    # @raise [ArgumentError] if offset is not between 0 and 23
+    # @example
+    #   For preferred_time_zone_name of 'Eastern Time (US & Canada)', use 3 for slow down at midnight PT/3am ET
+    #   For preferred_time_zone_name of 'Pacific Time (US & Canada)', use 0 for slow down at midnight PT/3am ET
+    def hour_offset_to_expire_cache=(offset)
+      raise ArgumentError, 'offset must be between 0 and 23' unless (0..23).cover? offset
+      @hour_offset_to_expire_cache = offset
+    end
+```
+
+With the default values set for the cache configurations, the cache will expire at midnight Pacific Time/3am Eastern Time.
+
+##### Process for updating monitoring tests
+
+Monitoring works in conjuction with the cache.  When the cache expires, the monitoring tests will run the next time the monitor status page is accessed.  When the monitor status page loads, it attempts to get the data for the page from the cache.  If the cache has expired, it will get the previous day's data and kick off a background job to run the tests and update the cache.
+
+##### Controlling when tests run
+
+Because this process is launched by access to the monitor status page, it will not by default run the monitoring tests everyday.  In our system, we set up Pingdom to access the monitor status page hourly around the clock.  If an error occurs during the latest testing, the monitor status page includes a CSS class `summary-status-bad` and displays error results.  Pingdom is configured to send a notification if the `summary-status-bad` CSS class is on the page, letting us know that we need to look into a problem with authority access.
+
+##### Setting up background jobs
+
+Reference: https://guides.rubyonrails.org/active_job_basics.html
+
+Since this job is not critical for end users, you can set up jobs to be processed by the ruby provided in-memory job queue.  The risk here is that if the server restarts or some other failure occurs, jobs in that queue are lost.  If this is unacceptable for your system, then you will want to setup a 3rd party job queue ([more info...](https://guides.rubyonrails.org/active_job_basics.html#starting-the-backend)).
+
+To configure in-memory job queue, add the following to config/environments/production.rb
+
+```
+  config.active_job.queue_adapter = :async # runs in-memory; a crash will lose the job
+```
 
 #### Test the install
 

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+# Job to run monitoring tests
+module QaServer
+  class MonitorTestsJob < ApplicationJob
+    include QaServer::AuthorityValidationBehavior
+
+    queue_as :default
+
+    class_attribute :scenario_run_registry_class
+    self.scenario_run_registry_class = QaServer::ScenarioRunRegistry
+
+    # def perform(job_id:)
+    def perform
+      Rails.cache.fetch("QaServer::MonitorTestsController/latest_run", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: true) do
+        job_id = SecureRandom.uuid
+        monitor_tests_job_id = job_id unless monitor_tests_job_id
+        if monitor_tests_job_id == job_id # avoid race conditions
+          QaServer.config.jobs_logger.info("(#{self.class}##{__method__}-#{job_id}) running monitoring tests")
+          validate(authorities_list)
+          scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
+          reset_monitor_tests_job_id
+        end
+        scenario_run_registry_class.latest_run
+      end
+    end
+
+    private
+
+      # @return [String, Boolean] Returns job id of the job currently running tests; otherwise, false if tests are not running
+      def monitor_tests_job_id
+        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 1.hour) { false }
+      end
+
+      # Set the id of the job that will run the tests.
+      # @param job_id [String] UUID for job running the tests
+      def monitor_tests_job_id=(job_id)
+        # check to see if there is a current job already running tests
+        current_job_id = Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 30.seconds) { job_id }
+
+        # current_job_id may be false meaning tests are not currently running; in which case, it is ok to force set job_id
+        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 30.seconds, force: true) { job_id } unless current_job_id
+      end
+
+      # Set job id for monitor tests to false indicating that tests are not currently running
+      def reset_monitor_tests_job_id
+        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 1.hour, force: true) { false }
+      end
+  end
+end

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -201,9 +201,15 @@ module QaServer
       @suppress_logging_performance_datails ||= false
     end
 
+    # For internal use only
     # TODO: consider refactor performance caching to use Rails cache
     def performance_cache
       @performance_cache ||= QaServer::PerformanceCache.new
+    end
+
+    # For internal use only
+    def jobs_logger
+      @jobs_logger ||= Logger.new(ENV['JOBS_LOG_PATH'] || File.join("log", "jobs.log"))
     end
   end
 end


### PR DESCRIPTION
Process prior to this PR ran monitoring tests inline.  They take > 30m to complete.  This caused Pingdom to timeout and report an error.  With this PR, the 3am Pingdom check will use the current data and kick off the background process to run the tests.  The 4am Pingdom check will report the actual up/down status. 