### PR TITLE
refactor generation of performance graphs

### DIFF
--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -29,7 +29,7 @@ module QaServer
 
       # @return [String, Boolean] Returns job id of the job currently running tests; otherwise, false if tests are not running
       def monitor_tests_job_id
-        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 1.hour) { false }
+        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 5.minutes) { false }
       end
 
       # Set the id of the job that will run the tests.
@@ -44,7 +44,7 @@ module QaServer
 
       # Set job id for monitor tests to false indicating that tests are not currently running
       def reset_monitor_tests_job_id
-        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 1.hour, force: true) { false }
+        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 30.seconds, force: true) { false }
       end
   end
 end

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -6,11 +6,9 @@ module QaServer
 
     enum action: [:fetch, :search]
 
-    class_attribute :stats_calculator_class, :graph_data_service_class, :graphing_service_class, :authority_list_class
-    self.stats_calculator_class = QaServer::PerformanceCalculatorService
+    class_attribute :datatable_data_service_class, :graph_data_service_class
+    self.datatable_data_service_class = QaServer::PerformanceDatatableService
     self.graph_data_service_class = QaServer::PerformanceGraphDataService
-    self.graphing_service_class = QaServer::PerformanceGraphingService
-    self.authority_list_class = QaServer::AuthorityListerService
 
     class << self
       include QaServer::PerformanceHistoryDataKeys
@@ -32,11 +30,25 @@ module QaServer
       # @example
       #   { all_authorities:
       #     { search:
+      #       { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+      #         retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+      #         retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 },
+      #       fetch: { ... # same data as for search_stats },
+      #       all: { ... # same data as for search_stats }
+      #     },
+      #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
+      #   }
+      def performance_table_data(force: false)
+        datatable_data_service_class.calculate_datatable_data(force: force)
+      end
+
+      # Performance data for a day, a month, a year, and all time for each authority.
+      # @param datatype [Symbol] what type of data should be calculated (e.g. :datatable, :graph, :all)
+      # @returns [Hash] performance statistics for the past 24 hours
+      # @example
+      #   { all_authorities:
+      #     { search:
       #       {
-      #         datatable_stats:
-      #           { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
-      #             retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
-      #             retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
       #         day:
       #           { 0: { hour: '1400', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
       #             1: { hour: '1500', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
@@ -59,90 +71,14 @@ module QaServer
       #             11: { month: '08-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
       #           }
       #       },
-      #       fetch: { ... # same data as for search_stats }
+      #       fetch: { ... # same data as for search_stats },
       #       all: { ... # same data as for search_stats }
       #     },
       #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
       #   }
-      def performance_data(datatype: :datatable, force: false)
-        return if datatype == :none
-        QaServer.config.performance_cache.write_all
-        data = calculate_data(datatype, force: force)
-        graphing_service_class.create_performance_graphs(performance_data: data) if calculate_graphdata? datatype
-        data
+      def performance_graph_data(force: false)
+        graph_data_service_class.calculate_graph_data(force: force)
       end
-
-      private
-
-        def calculate_datatable?(datatype)
-          datatype == :datatable || datatype == :all
-        end
-
-        def calculate_graphdata?(datatype)
-          datatype == :graph || datatype == :all
-        end
-
-        def calculate_data(datatype, force:)
-          data = {}
-          auths = authority_list_class.authorities_list
-          data[ALL_AUTH] = data_for_authority(datatype: datatype, force: force)
-          auths.each { |auth_name| data[auth_name] = data_for_authority(authority_name: auth_name, datatype: datatype, force: force) }
-          data
-        end
-
-        def data_for_authority(authority_name: nil, datatype:, force:)
-          action_data = {}
-          [:search, :fetch, :all_actions].each do |action|
-            data = {}
-            data[FOR_DATATABLE] = data_table_stats(authority_name, action, force: force) if calculate_datatable?(datatype)
-            if calculate_graphdata?(datatype)
-              data[FOR_DAY] = graph_data_service_class.average_last_24_hours(authority_name: authority_name, action: action, force: force)
-              data[FOR_MONTH] = graph_data_service_class.average_last_30_days(authority_name: authority_name, action: action, force: force)
-              data[FOR_YEAR] = graph_data_service_class.average_last_12_months(authority_name: authority_name, action: action, force: force)
-            end
-            action_data[action] = data
-          end
-          action_data
-        end
-
-        # Get statistics for all available data.
-        # @param auth_name [String] limit statistics to records for the given authority (default: all authorities)
-        # @param action [Symbol] one of :search, :fetch, :all_actions
-        # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
-        # @returns [Hash] performance statistics for the datatable during the expected time period
-        # @example
-        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
-        #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
-        #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
-        def data_table_stats(auth_name, action, force:)
-          Rails.cache.fetch("#{self.class}/#{__method__}/#{auth_name || ALL_AUTH}/#{action}/#{FOR_DATATABLE}",
-                            expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: force) do
-            Rails.logger.info("#{self.class}##{__method__} - calculating performance datatable stats - cache expired or refresh requested (#{force})")
-            records = records_for_authority(auth_name)
-            stats_calculator_class.new(records, action: action).calculate_stats(avg: true, low: true, high: true)
-          end
-        end
-
-        def expected_time_period
-          QaServer.config.performance_datatable_default_time_period
-        end
-
-        def records_for_authority(auth_name)
-          case expected_time_period
-          when :day
-            where(QaServer::TimePeriodService.where_clause_for_last_24_hours(auth_name: auth_name))
-          when :month
-            where(QaServer::TimePeriodService.where_clause_for_last_30_days(auth_name: auth_name))
-          when :year
-            where(QaServer::TimePeriodService.where_clause_for_last_12_months(auth_name: auth_name))
-          else
-            all_records(auth_name)
-          end
-        end
-
-        def all_records(auth_name)
-          auth_name.nil? ? PerformanceHistory.all : where(authority: auth_name)
-        end
     end
   end
 end

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -45,7 +45,7 @@ module QaServer
       #   * total_scenario_count: 159,
       def run_summary(scenario_run:, force: false)
         Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          Rails.logger.info("QaServer::ScenarioRunHistory##{__method__} - creating summary of latest run - cache expired or refresh requested (#{force})")
+          QaServer.config.monitor_logger.info("(QaServer::ScenarioRunHistory##{__method__}) - creating summary of latest run - cache expired or refresh requested (force: #{force})")
           status = status_counts_in_run(run_id: scenario_run.id)
           summary_class.new(run_id: scenario_run.id,
                             run_dt_stamp: scenario_run.dt_stamp,
@@ -128,7 +128,7 @@ module QaServer
       def run_failures(run_id:, force: false)
         return [] unless run_id
         Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          Rails.logger.info("QaServer::ScenarioRunHistory##{__method__} - finding failures in latest run - cache expired or refresh requested (#{force})")
+          QaServer.config.monitor_logger.info("(QaServer::ScenarioRunHistory##{__method__}) - finding failures in latest run - cache expired or refresh requested (force: #{force})")
           QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: :good).to_a
         end
       end

--- a/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
@@ -123,7 +123,7 @@ module QaServer::MonitorStatus
       end
 
       def data_table_for(authority_data, action)
-        authority_data[action][FOR_DATATABLE]
+        authority_data[action]
       end
 
       def unsupported_action?(stats)

--- a/app/presenters/qa_server/monitor_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status_presenter.rb
@@ -7,7 +7,7 @@ module QaServer
     # @param current_summary [ScenarioRunSummary] summary status of the latest run of test scenarios
     # @param current_data [Array<Hash>] current set of failures for the latest test run, if any
     # @param historical_summary_data [Array<Hash>] summary of past failuring runs per authority to drive chart
-    # @param performance_data [Hash<Hash>] performance data
+    # @param performance_data [Hash<Hash>] performance datatable data
     def initialize(current_summary:, current_failure_data:, historical_summary_data:, performance_data:)
       @current_status_presenter = QaServer::MonitorStatus::CurrentStatusPresenter.new(parent: self, current_summary: current_summary, current_failure_data: current_failure_data)
       @history_presenter = QaServer::MonitorStatus::HistoryPresenter.new(parent: self, historical_summary_data: historical_summary_data)

--- a/app/services/qa_server/performance_calculator_service.rb
+++ b/app/services/qa_server/performance_calculator_service.rb
@@ -14,18 +14,29 @@ module QaServer
       @stats = {}
     end
 
-    # Calculate performance statistics for a set of PerformanceHistory records.  Min is at the 10th percentile.  Max is at the 90th percentile.
+    # Calculate performance statistics with percentiles.  Min is at the 10th percentile.  Max is at the 90th percentile.
     # @return [Hash] hash of the statistics
     # @example
     #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
     #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
     #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
-    def calculate_stats(avg: false, low: false, high: false, load: true, norm: true, full: true) # rubocop:disable Metrics/ParameterLists
-      calculate_load_stats(avg, low, high) if load
-      calculate_retrieve_stats(avg, low, high) if load
-      calculate_graph_load_stats(avg, low, high) if load
-      calculate_normalization_stats(avg, low, high) if norm
-      calculate_action_stats(avg, low, high) if full
+    def calculate_stats_with_percentiles
+      calculate_retrieve_stats(true, true, true)
+      calculate_graph_load_stats(true, true, true)
+      calculate_normalization_stats(true, true, true)
+      calculate_action_stats(true, true, true)
+      stats
+    end
+
+    # Calculate performance statistics including averages only.
+    # @return [Hash] hash of the statistics
+    # @example
+    #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5 }
+    def calculate_average_stats
+      calculate_load_stats(true, false, false) # used for backward compatibility only
+      calculate_retrieve_stats(true, false, false)
+      calculate_graph_load_stats(true, false, false)
+      calculate_normalization_stats(true, false, false)
       stats
     end
 

--- a/app/services/qa_server/performance_datatable_service.rb
+++ b/app/services/qa_server/performance_datatable_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+# This class calculates performance stats for the performance datatable.
+module QaServer
+  class PerformanceDatatableService
+    class << self
+      include QaServer::PerformanceHistoryDataKeys
+
+      class_attribute :stats_calculator_class, :performance_data_class, :authority_list_class
+      self.stats_calculator_class = QaServer::PerformanceCalculatorService
+      self.performance_data_class = QaServer::PerformanceHistory
+      self.authority_list_class = QaServer::AuthorityListerService
+
+      # Summary of performance by action for each authority for the configured time period (e.g. :day, :month, :year, :all).
+      # @param force [Boolean] if true, calculate the stats even if the cache hasn't expired; otherwise, use cache if not expired
+      # @returns [Hash] performance statistics for configured time period by action for each authority
+      # @example
+      #   { all_authorities:
+      #     { search:
+      #       { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+      #         retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+      #         retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 },
+      #       fetch: { ... # same data as for search_stats },
+      #       all: { ... # same data as for search_stats }
+      #     },
+      #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
+      #   }
+      def calculate_datatable_data(force:)
+        Rails.cache.fetch("QaServer::PerformanceDatatableService/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 5.minutes, force: force) do
+          QaServer.config.monitor_logger.info("(QaServer::PerformanceDatatableService##{__method__}) - calculating performance datatable stats - cache expired or refresh requested (force: #{force})")
+          data = {}
+          auths = authority_list_class.authorities_list
+          data[ALL_AUTH] = datatable_data_for_authority
+          auths.each { |auth_name| data[auth_name] = datatable_data_for_authority(authority_name: auth_name) }
+          data
+        end
+      end
+
+      private
+
+        def datatable_data_for_authority(authority_name: nil)
+          [:search, :fetch, :all_actions].each_with_object({}) do |action, hash|
+            hash[action] = data_table_stats(authority_name, action)
+          end
+        end
+
+        # Get statistics for data table.
+        # @param auth_name [String] limit statistics to records for the given authority (default: all authorities)
+        # @param action [Symbol] one of :search, :fetch, :all_actions
+        # @returns [Hash] performance statistics for the datatable during the expected time period
+        # @example
+        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+        #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+        #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
+        def data_table_stats(auth_name, action)
+          records = records_for_authority(auth_name)
+          stats_calculator_class.new(records, action: action).calculate_stats_with_percentiles
+        end
+
+        def expected_time_period
+          QaServer.config.performance_datatable_default_time_period
+        end
+
+        def records_for_authority(auth_name)
+          case expected_time_period
+          when :day
+            QaServer.config.performance_cache.write_all # only need to write if just using today's data
+            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_24_hours(auth_name: auth_name))
+          when :month
+            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_30_days(auth_name: auth_name))
+          when :year
+            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_12_months(auth_name: auth_name))
+          else
+            all_records(auth_name)
+          end
+        end
+
+        def all_records(auth_name)
+          auth_name.nil? ? performance_data_class.all : performance_data_class.where(authority: auth_name)
+        end
+    end
+  end
+end

--- a/app/services/qa_server/performance_graph_data_service.rb
+++ b/app/services/qa_server/performance_graph_data_service.rb
@@ -1,76 +1,133 @@
 # frozen_string_literal: true
 # This class sets performance stats for the last 24 hours, past 30 days, and the past 12 months.
 module QaServer
-  class PerformanceGraphDataService
+  class PerformanceGraphDataService # rubocop:disable Metrics/ClassLength
     class << self
       include QaServer::PerformanceHistoryDataKeys
 
-      class_attribute :stats_calculator_class, :performance_data_class
+      class_attribute :stats_calculator_class, :performance_data_class, :authority_list_class
       self.stats_calculator_class = QaServer::PerformanceCalculatorService
       self.performance_data_class = QaServer::PerformanceHistory
+      self.authority_list_class = QaServer::AuthorityListerService
 
-      # Get hourly average for the past 24 hours.
-      # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
-      # @param action [Symbol] one of :search, :fetch, :all_actions
-      # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
+      # Performance data for a day, a month, a year, and all time for each authority.
+      # @param datatype [Symbol] what type of data should be calculated (e.g. :datatable, :graph, :all)
       # @returns [Hash] performance statistics for the past 24 hours
       # @example
-      #   { 0: { hour: '1400', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     1: { hour: '1500', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     2: { hour: '1600', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     ...,
-      #     23: { hour: 'NOW', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #   { all_authorities:
+      #     { search:
+      #       {
+      #         day:
+      #           { 0: { hour: '1400', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { hour: '1500', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { hour: '1600', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             23: { hour: 'NOW', retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           },
+      #         month:
+      #           { 0: { day: '07-15-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { day: '07-16-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { day: '07-17-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             29: { day: 'TODAY', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           },
+      #         year:
+      #           { 0: { month: '09-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             1: { month: '10-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             2: { month: '11-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+      #             ...,
+      #             11: { month: '08-2019', stats: { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+      #           }
+      #       },
+      #       fetch: { ... # same data as for search_stats },
+      #       all: { ... # same data as for search_stats }
+      #     },
+      #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
       #   }
-      def average_last_24_hours(authority_name: nil, action: nil, force: false)
-        Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_DAY}",
-                          expires_in: QaServer::TimeService.current_time.end_of_hour - QaServer::TimeService.current_time,
-                          race_condition_ttl: 1.hour, force: force) do
-          Rails.logger.info("#{self.class}##{__method__} - calculating performance stats for last 24 hours - cache expired or refresh requested (#{force})")
-          calculate_last_24_hours(authority_name, action)
-        end
-      end
-
-      # Get daily average for the past 30 days.
-      # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
-      # @param action [Symbol] one of :search, :fetch, :all_actions
-      # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
-      # @returns [Hash] performance statistics for the past 30 days
-      # @example
-      #   { 0: { day: '07-15-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     1: { day: '07-16-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     2: { day: '07-17-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     ...,
-      #     29: { day: 'TODAY', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
-      #   }
-      def average_last_30_days(authority_name: nil, action: nil, force: false)
-        Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_MONTH}",
-                          expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: force) do
-          Rails.logger.info("#{self.class}##{__method__} - calculating performance stats for last 30 days - cache expired or refresh requested (#{force})")
-          calculate_last_30_days(authority_name, action)
-        end
-      end
-
-      # Get daily average for the past 12 months.
-      # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
-      # @param action [Symbol] one of :search, :fetch, :all_actions
-      # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
-      # @returns [Hash] performance statistics for the past 12 months
-      # @example
-      #   { 0: { month: '09-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     1: { month: '10-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     2: { month: '11-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
-      #     ...,
-      #     11: { month: '08-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
-      #   }
-      def average_last_12_months(authority_name: nil, action: nil, force: false)
-        Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_YEAR}",
-                          expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: force) do
-          Rails.logger.info("#{self.class}##{__method__} - calculating performance stats for last 12 months - cache expired or refresh requested (#{force})")
-          calculate_last_12_months(authority_name, action)
-        end
+      def calculate_graph_data(force:)
+        QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphDataService##{__method__}) - calculating performance graph data")
+        QaServer.config.performance_cache.write_all
+        data = {}
+        auths = authority_list_class.authorities_list
+        calculate_all = force || cache_expired?
+        data[ALL_AUTH] = graph_data_for_authority(force: force, calculate_all: calculate_all)
+        auths.each { |auth_name| data[auth_name] = graph_data_for_authority(authority_name: auth_name, force: force, calculate_all: calculate_all) }
+        data
       end
 
       private
+
+        def graph_data_for_authority(authority_name: nil, force:, calculate_all:)
+          [:search, :fetch, :all_actions].each_with_object({}) do |action, hash|
+            data = {}
+            data[FOR_DAY] = average_last_24_hours(authority_name: authority_name, action: action, force: force)
+            data[FOR_MONTH] = average_last_30_days(authority_name: authority_name, action: action, force: force) if calculate_all
+            data[FOR_YEAR] = average_last_12_months(authority_name: authority_name, action: action, force: force) if calculate_all
+            hash[action] = data
+          end
+        end
+
+        # Get hourly average for the past 24 hours.
+        # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
+        # @param action [Symbol] one of :search, :fetch, :all_actions
+        # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
+        # @returns [Hash] performance statistics for the past 24 hours
+        # @example
+        #   { 0: { hour: '1400', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     1: { hour: '1500', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     2: { hour: '1600', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     ...,
+        #     23: { hour: 'NOW', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+        #   }
+        def average_last_24_hours(authority_name: nil, action: nil, force: false)
+          avgs = Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_DAY}",
+                                   expires_in: QaServer::TimeService.current_time.end_of_hour - QaServer::TimeService.current_time,
+                                   race_condition_ttl: 1.hour, force: force) do
+            QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphDataService##{__method__}) - calculating performance stats - cache expired or refresh requested (force: #{force})")
+            calculate_last_24_hours(authority_name, action)
+          end
+          calculate_last_hour(authority_name, action, avgs)
+        end
+
+        # Get daily average for the past 30 days.
+        # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
+        # @param action [Symbol] one of :search, :fetch, :all_actions
+        # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
+        # @returns [Hash] performance statistics for the past 30 days
+        # @example
+        #   { 0: { day: '07-15-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     1: { day: '07-16-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     2: { day: '07-17-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     ...,
+        #     29: { day: 'TODAY', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+        #   }
+        def average_last_30_days(authority_name: nil, action: nil, force: false)
+          Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_MONTH}",
+                            expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: force) do
+            QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphDataService##{__method__}) - calculating performance stats - cache expired or refresh requested (force: #{force})")
+            calculate_last_30_days(authority_name, action)
+          end
+        end
+
+        # Get daily average for the past 12 months.
+        # @param authority_name [String] limit statistics to records for the given authority (default: all authorities)
+        # @param action [Symbol] one of :search, :fetch, :all_actions
+        # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
+        # @returns [Hash] performance statistics for the past 12 months
+        # @example
+        #   { 0: { month: '09-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     1: { month: '10-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     2: { month: '11-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }},
+        #     ...,
+        #     11: { month: '08-2019', stats: { load_avg_ms: 12.3, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5, etc. }}
+        #   }
+        def average_last_12_months(authority_name: nil, action: nil, force: false)
+          Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}/#{authority_name || ALL_AUTH}/#{action}/#{FOR_YEAR}",
+                            expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.hour, force: force) do
+            QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphDataService##{__method__}) - calculating performance stats - cache expired or refresh requested (force: #{force})")
+            calculate_last_12_months(authority_name, action)
+          end
+        end
 
         def records_by(authority_name, action, time_period)
           where_clause = { dt_stamp: time_period }
@@ -99,49 +156,50 @@ module QaServer
           end
         end
 
+        def calculate_from_records(records, range_idx, range_label)
+          stats = stats_calculator_class.new(records).calculate_average_stats
+          { STATS => stats, range_idx => range_label }
+        end
+
+        def calculate_last_hour(authority_name, action, avgs)
+          start_hour = QaServer::TimeService.current_time.beginning_of_hour
+          records = records_by(authority_name, action, start_hour..start_hour.end_of_hour)
+          avgs[23] = calculate_from_records(records, BY_HOUR, performance_by_hour_label(23, start_hour))
+          avgs
+        end
+
         def calculate_last_24_hours(authority_name, action)
           start_hour = QaServer::TimeService.current_time.beginning_of_hour - 23.hours
-          avgs = {}
-          0.upto(23).each do |idx|
+          0.upto(23).each_with_object({}) do |idx, avgs|
             records = records_by(authority_name, action, start_hour..start_hour.end_of_hour)
-            stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
-            data = {}
-            data[BY_HOUR] = performance_by_hour_label(idx, start_hour)
-            data[STATS] = stats
-            avgs[idx] = data
+            avgs[idx] = calculate_from_records(records, BY_HOUR, performance_by_hour_label(idx, start_hour))
             start_hour += 1.hour
           end
-          avgs
         end
 
         def calculate_last_30_days(authority_name, action)
           start_day = QaServer::TimeService.current_time.beginning_of_day - 29.days
-          avgs = {}
-          0.upto(29).each do |idx|
+          0.upto(29).each_with_object({}) do |idx, avgs|
             records = records_by(authority_name, action, start_day..start_day.end_of_day)
-            stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
-            data = {}
-            data[BY_DAY] = performance_by_day_label(idx, start_day)
-            data[STATS] = stats
-            avgs[idx] = data
+            avgs[idx] = calculate_from_records(records, BY_DAY, performance_by_day_label(idx, start_day))
             start_day += 1.day
           end
-          avgs
         end
 
         def calculate_last_12_months(authority_name, action)
           start_month = QaServer::TimeService.current_time.beginning_of_month - 11.months
-          avgs = {}
-          0.upto(11).each do |idx|
+          0.upto(11).each_with_object({}) do |idx, avgs|
             records = records_by(authority_name, action, start_month..start_month.end_of_month)
-            stats = stats_calculator_class.new(records).calculate_stats(avg: true, full: false)
-            data = {}
-            data[BY_MONTH] = start_month.strftime("%m-%Y")
-            data[STATS] = stats
-            avgs[idx] = data
+            avgs[idx] = calculate_from_records(records, BY_MONTH, start_month.strftime("%m-%Y"))
             start_month += 1.month
           end
-          avgs
+        end
+
+        # @returns [Boolean] true if cache has expired; otherwise, false
+        def cache_expired?
+          expired = Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}", expires_in: 5.seconds) { true }
+          Rails.cache.fetch("QaServer::PerformanceGraphDataService/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, force: expired) { false } # reset if expired
+          expired
         end
     end
   end


### PR DESCRIPTION
Refactor includes…
* commit performance data before calculating
* cache performance graph data expiring once per day for month and year data
* cache performance graph data expiring on the hour
* calculate last hour of performance data for Day graphs (This is the only calculation that happens everytime the monitor status page loads.)