### PR TITLE
add performance cache logger

### DIFF
--- a/app/controllers/qa_server/check_status_controller.rb
+++ b/app/controllers/qa_server/check_status_controller.rb
@@ -41,8 +41,8 @@ module QaServer
       end
 
       def log_header
-        QaServer.config.monitor_logger.debug("-------------------------------------  check status  ---------------------------------")
-        QaServer.config.monitor_logger.info("(#{self.class}##{__method__}) check status page request (authority_name # #{authority_name})")
+        QaServer.config.performance_cache_logger.debug("-------------------------------------  check status  ---------------------------------")
+        QaServer.config.performance_cache_logger.debug("(#{self.class}##{__method__}) check status page request (authority_name # #{authority_name})")
       end
   end
 end

--- a/app/controllers/qa_server/monitor_status_controller.rb
+++ b/app/controllers/qa_server/monitor_status_controller.rb
@@ -40,7 +40,7 @@ module QaServer
       # @see #latest_test_run_from_temp_cache
       def latest_test_run_from_cache
         Rails.cache.fetch("#{self.class}/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 5.minutes, force: refresh_tests?) do
-          QaServer.config.monitor_logger.info("(#{self.class}##{__method__}) get latest run of monitoring tests - cache expired or refresh requested (force: #{refresh_tests?})")
+          QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}) get latest run of monitoring tests - cache expired or refresh requested (force: #{refresh_tests?})")
           QaServer::MonitorTestsJob.perform_later
           scenario_run_registry_class.latest_run
         end
@@ -105,7 +105,7 @@ module QaServer
 
       def log_header
         QaServer.config.monitor_logger.debug("-------------------------------------  monitor status  ---------------------------------")
-        QaServer.config.monitor_logger.info("(#{self.class}##{__method__}) monitor status page request (refresh_tests? # #{refresh_tests?}, " \
+        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}) monitor status page request (refresh_tests? # #{refresh_tests?}, " \
                                          "refresh_history? # #{refresh_history?}, refresh_performance? # #{refresh_performance?})")
       end
   end

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -22,11 +22,11 @@ module QaServer
     private
 
       def run_tests
-        QaServer.config.monitor_logger.info("(#{self.class}##{__method__}-#{job_id}) RUNNING monitoring tests")
+        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) RUNNING monitoring tests")
         validate(authorities_list)
         log_results(authorities_list, status_log.to_a)
         scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
-        QaServer.config.monitor_logger.info("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
+        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
         reset_monitor_tests_job_id
       end
 

--- a/app/models/qa_server/performance_cache.rb
+++ b/app/models/qa_server/performance_cache.rb
@@ -23,7 +23,7 @@ module QaServer
 
     def complete_entry(id:)
       log(id: id)
-      QaServer.config.monitor_logger.info("#{self.class}##{__method__} - id: #{id}   cache memory: #{ObjectSpace.memsize_of @cache}")
+      QaServer.config.performance_cache_logger.debug("#{self.class}##{__method__} - id: #{id}   cache memory: #{ObjectSpace.memsize_of @cache}")
       write_all if ObjectSpace.memsize_of(@cache) > QaServer.config.max_performance_cache_size
     end
 
@@ -52,7 +52,7 @@ module QaServer
       def swap_cache_hash
         cache_to_write = @cache
         @cache = {} # reset main cache so new items after write begins are cached in the main cache
-        QaServer.config.monitor_logger.info("#{self.class}##{__method__} - cache memory BEFORE write: #{ObjectSpace.memsize_of(cache_to_write)}")
+        QaServer.config.performance_cache_logger.debug("#{self.class}##{__method__} - cache memory BEFORE write: #{ObjectSpace.memsize_of(cache_to_write)}")
         cache_to_write
       end
 
@@ -80,12 +80,12 @@ module QaServer
 
       def log_write_all(prefix, size_before, cache_size)
         if size_before.positive?
-          QaServer.config.monitor_logger.warn("#{prefix} 0 of #{size_before} performance data records were saved") if size_before == cache_size
-          QaServer.config.monitor_logger.info("#{prefix} #{size_before - cache_size} of #{size_before} performance data records were saved") if size_before > cache_size
+          QaServer.config.performance_cache_logger.debug("#{prefix} 0 of #{size_before} performance data records were saved") if size_before == cache_size
+          QaServer.config.performance_cache_logger.debug("#{prefix} #{size_before - cache_size} of #{size_before} performance data records were saved") if size_before > cache_size
         else
-          QaServer.config.monitor_logger.info("#{prefix} 0 of 0 performance data records were saved")
+          QaServer.config.performance_cache_logger.debug("#{prefix} 0 of 0 performance data records were saved")
         end
-        QaServer.config.monitor_logger.info("#{prefix} - cache memory AFTER write: #{ObjectSpace.memsize_of @cache}")
+        QaServer.config.performance_cache_logger.debug("#{prefix} - cache memory AFTER write: #{ObjectSpace.memsize_of @cache}")
       end
   end
 end

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -47,7 +47,7 @@ module QaServer
       #   * total_scenario_count: 159,
       def run_summary(scenario_run:, force: false)
         Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.info("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING summary of latest run - cache expired or refresh requested (force: #{force})")
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING summary of latest run - cache expired or refresh requested (force: #{force})")
           status = status_counts_in_run(run_id: scenario_run.id)
           summary_class.new(run_id: scenario_run.id,
                             run_dt_stamp: scenario_run.dt_stamp,
@@ -130,7 +130,7 @@ module QaServer
       def run_failures(run_id:, force: false)
         return [] unless run_id
         Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.info("(QaServer::ScenarioRunHistory##{__method__}) - finding failures in latest run - cache expired or refresh requested (force: #{force})")
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - finding failures in latest run - cache expired or refresh requested (force: #{force})")
           QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: :good).to_a
         end
       end
@@ -142,7 +142,7 @@ module QaServer
       #     'geonames_ld4l_cache' => { good: 32, bad: 1 } }
       def historical_summary(force: false)
         Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.info("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING authority connection history - cache expired or refresh requested (force: #{force})")
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING authority connection history - cache expired or refresh requested (force: #{force})")
           days_good = count_days(:good)
           days_bad = count_days(:bad)
           days_unknown = count_days(:unknown)

--- a/app/services/qa_server/performance_datatable_service.rb
+++ b/app/services/qa_server/performance_datatable_service.rb
@@ -26,7 +26,7 @@ module QaServer
       #   }
       def calculate_datatable_data(force:)
         Rails.cache.fetch("QaServer::PerformanceDatatableService/#{__method__}", expires_in: QaServer::MonitorCacheService.cache_expiry, race_condition_ttl: 5.minutes, force: force) do
-          QaServer.config.monitor_logger.info("(QaServer::PerformanceDatatableService##{__method__}) - CALCULATING performance datatable stats - cache expired or refresh requested (force: #{force})")
+          QaServer.config.monitor_logger.debug("(QaServer::PerformanceDatatableService##{__method__}) - CALCULATING performance datatable stats - cache expired or refresh requested (force: #{force})")
           data = {}
           auths = authority_list_class.authorities_list
           data[ALL_AUTH] = datatable_data_for_authority

--- a/app/services/qa_server/performance_graph_data_service.rb
+++ b/app/services/qa_server/performance_graph_data_service.rb
@@ -49,7 +49,7 @@ module QaServer
         data = {}
         auths = authority_list_class.authorities_list
         calculate_all = force || cache_expired?
-        QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphDataService##{__method__}) - CALCULATING performance graph data (calculate_all: #{calculate_all})")
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceGraphDataService##{__method__}) - CALCULATING performance graph data (calculate_all: #{calculate_all})")
         data[ALL_AUTH] = graph_data_for_authority(force: force, calculate_all: calculate_all)
         auths.each { |auth_name| data[auth_name] = graph_data_for_authority(authority_name: auth_name, force: force, calculate_all: calculate_all) }
         data

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -12,7 +12,7 @@ module QaServer
       # @param performance_data [Hash] hash of all performance data for all authorities
       # @see QaServer:PerformanceHistory
       def create_performance_graphs(performance_data:)
-        QaServer.config.monitor_logger.info("(QaServer::PerformanceGraphingService##{__method__}) - generating graphs")
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceGraphingService##{__method__}) - generating graphs")
         performance_data.each_key do |auth_name|
           create_graphs_for_authority(performance_data, auth_name.to_sym, :search)
           create_graphs_for_authority(performance_data, auth_name.to_sym, :fetch)

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -213,6 +213,31 @@ module QaServer
       @performance_cache ||= QaServer::PerformanceCache.new
     end
 
+    # Enable logging of performance cache
+    def enable_performance_cache_logging
+      performance_cache_logger.level = Logger::DEBUG
+    end
+
+    # Disable logging of performance cache
+    def disable_performance_cache_logging
+      performance_cache_logger.level = Logger::INFO
+    end
+
+    # For internal use only
+    def performance_cache_logger
+      @performance_cache_logger ||= Logger.new(ENV['PERFORMANCE_CACHE_LOG_PATH'] || File.join("log", "performance_cache.log"))
+    end
+
+    # Enable logging of monitoring process
+    def enable_monitor_status_logging
+      monitor_logger.level = Logger::DEBUG
+    end
+
+    # Disable logging of performance cache
+    def disable_monitor_status_logging
+      monitor_logger.level = Logger::INFO
+    end
+
     # For internal use only
     def monitor_logger
       @monitor_logger ||= Logger.new(ENV['MONITOR_LOG_PATH'] || File.join("log", "monitor.log"))


### PR DESCRIPTION
Also…
* set all monitor_logger messages to debug
* set all performance_cache_logger messages to debug
* add enable/disable_monitor_status_logging config
* add enable/disable_performance_cache_logging config

By default (according to Rails logger default behaviors), logging in development environment is enabled and logging in production environment is disabled.