### PR TITLE
move performance datatable cache control to cache_processors

### DIFF
--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -2,12 +2,12 @@
 # This module sets up the keys used to identify data in Rails.cache
 module QaServer
   module CacheKeys
-    RUN_SUMMARY_DATA = "QaServer::CacheKeys.run_summary_data"
-    RUN_HISTORY_DATA = "QaServer::CacheKeys.run_history_data"
+    RUN_SUMMARY_DATA_CACHE_KEY = "QaServer--CacheKeys--run_summary_data"
+    RUN_HISTORY_DATA_CACHE_KEY = "QaServer--CacheKeys--run_history_data"
 
-    PERFORMANCE_DATATABLE_DATA = "QaServer::CacheKeys.performance_datatable_data"
-    PERFORMANCE_GRAPH_HOURLY_DATA = "QaServer::CacheKeys.performance_graph_hourly_data"
-    PERFORMANCE_GRAPH_DAILY_DATA = "QaServer::CacheKeys.performance_graph_daily_data"
-    PERFORMANCE_GRAPH_MONTHLY_DATA = "QaServer::CacheKeys.performance_graph_monthly_data"
+    PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
+    PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"
+    PERFORMANCE_GRAPH_DAILY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_daily_data"
+    PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_monthly_data"
   end
 end

--- a/app/cache_processors/qa_server/cache_expiry_service.rb
+++ b/app/cache_processors/qa_server/cache_expiry_service.rb
@@ -8,6 +8,17 @@ module QaServer
         cache_expires_at - QaServer::TimeService.current_time
       end
 
+      # @param key [String] cache key
+      # @param force [Boolean] if true, forces cache to regenerate by returning true; otherwise, uses cache expiry to determine whether cache has expired
+      # @return [Boolean] true if cache has expired or is being forced to expire
+      def cache_expired?(key:, force:, next_expiry:)
+        # will return true only if the full expiry has passed or force was requested
+        force = Rails.cache.fetch(key, expires_in: 5.minutes, race_condition_ttl: 30.seconds, force: force) { true }
+        # reset cache so it will next expired at expected time
+        Rails.cache.fetch(key, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: true) { false }
+        force
+      end
+
       private
 
         # @return [ActiveSupport::TimeWithZone] DateTime at which cache should expire

--- a/app/cache_processors/qa_server/performance_daily_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_daily_graph_cache.rb
@@ -8,32 +8,35 @@ module QaServer
     self.graphing_service = QaServer::PerformanceGraphingService
 
     class << self
+      include QaServer::CacheKeys
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
       def generate_graphs(force: false)
-        generate_graphs_for_authorities(force: force)
+        return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceDailyGraphCache) - GENERATING daily performance graphs (force: #{force})")
+        generate_graphs_for_authorities
       end
 
       private
 
-        def generate_graphs_for_authorities(force:)
+        def generate_graphs_for_authorities
           auths = authority_list_class.authorities_list
-          generate_graphs_for_authority(authority_name: ALL_AUTH, force: force) # generates graph for all authorities
-          auths.each { |authname| generate_graphs_for_authority(authority_name: authname, force: force) }
+          generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+          auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
         end
 
-        def generate_graphs_for_authority(authority_name:, force:)
+        def generate_graphs_for_authority(authority_name:)
           [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-            hash[action] = generate_30_day_graph(authority_name: authority_name, action: action, force: force)
+            hash[action] = generate_30_day_graph(authority_name: authority_name, action: action)
           end
         end
 
-        def generate_30_day_graph(authority_name:, action:, force:)
+        def generate_30_day_graph(authority_name:, action:)
+          # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
+          # or force was requested.  We still expire the cache and use ttl to catch race conditions.
           Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
-                            expires_in: QaServer::CacheExpiryService.cache_expiry,
-                            race_condition_ttl: 1.hour, force: force) do
-            QaServer.config.monitor_logger.debug("(QaServer::PerformanceDailyGraphCache) - GENERATING daily performance graphs")
+                            expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
             data = graph_data_service.calculate_last_30_days(authority_name: authority_name, action: action)
             graphing_service.generate_daily_graph(authority_name: authority_name, action: action, data: data)
             data
@@ -41,7 +44,15 @@ module QaServer
         end
 
         def cache_key_for_authority_action(authority_name:, action:)
-          "#{QaServer::CacheKeys::PERFORMANCE_GRAPH_DAILY_DATA}-#{authority_name}-#{action}"
+          "#{PERFORMANCE_GRAPH_DAILY_DATA_CACHE_KEY}--#{authority_name}--#{action}"
+        end
+
+        def cache_key_for_force
+          "#{PERFORMANCE_GRAPH_DAILY_DATA_CACHE_KEY}--force"
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
         end
     end
   end

--- a/app/cache_processors/qa_server/performance_datatable_cache.rb
+++ b/app/cache_processors/qa_server/performance_datatable_cache.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# Maintain a cache of data for the Performance Datatable
+module QaServer
+  class PerformanceDatatableCache
+    include QaServer::CacheKeys
+
+    class_attribute :performance_data_service
+    self.performance_data_service = QaServer::PerformanceDatatableService
+
+    # Retrieve performance datatable data from the cache
+    # @param force [Boolean] if true, calculate the stats even if the cache hasn't expired; otherwise, use cache if not expired
+    # @returns [Hash] performance statistics for configured time period by action for each authority
+    # @example
+    #   { all_authorities:
+    #     { search:
+    #       { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+    #         retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+    #         retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 },
+    #       fetch: { ... # same data as for search_stats },
+    #       all: { ... # same data as for search_stats }
+    #     },
+    #     AGROVOC_LD4L_CACHE: { ... # same data for each authority  }
+    #   }
+    def self.data(force: false)
+      Rails.cache.fetch(PERFORMANCE_DATATABLE_DATA_CACHE_KEY,
+                        expires_in: QaServer::CacheExpiryService.cache_expiry,
+                        race_condition_ttl: 5.minutes, force: force) do
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceDatatableCache) - CALCULATING performance datatable stats (force: #{force})")
+        performance_data_service.calculate_datatable_data
+      end
+    end
+  end
+end

--- a/app/cache_processors/qa_server/performance_hourly_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_hourly_graph_cache.rb
@@ -9,11 +9,12 @@ module QaServer
     self.graphing_service = QaServer::PerformanceGraphingService
 
     class << self
+      include QaServer::CacheKeys
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 24 hours for :search, :fetch, and :all actions for each authority.
       def generate_graphs(force: false)
-        QaServer.config.monitor_logger.debug("(QaServer::PerformanceHourlyGraphCache) - GENERATING hourly performance graphs")
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceHourlyGraphCache) - GENERATING hourly performance graphs (force: #{force})")
         QaServer.config.performance_cache.write_all
         generate_graphs_for_authorities(force: force)
       end
@@ -56,7 +57,7 @@ module QaServer
         end
 
         def cache_key_for_authority_action(authority_name:, action:)
-          "#{QaServer::CacheKeys::PERFORMANCE_GRAPH_HOURLY_DATA}-#{authority_name}-#{action}"
+          "#{PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY}--#{authority_name}--#{action}"
         end
     end
   end

--- a/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
@@ -8,32 +8,35 @@ module QaServer
     self.graphing_service = QaServer::PerformanceGraphingService
 
     class << self
+      include QaServer::CacheKeys
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
       def generate_graphs(force: false)
-        generate_graphs_for_authorities(force: force)
+        return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
+        QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - GENERATING monthly performance graphs (force: #{force})")
+        generate_graphs_for_authorities
       end
 
       private
 
-        def generate_graphs_for_authorities(force:)
+        def generate_graphs_for_authorities
           auths = authority_list_class.authorities_list
-          generate_graphs_for_authority(authority_name: ALL_AUTH, force: force) # generates graph for all authorities
-          auths.each { |authname| generate_graphs_for_authority(authority_name: authname, force: force) }
+          generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+          auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
         end
 
-        def generate_graphs_for_authority(authority_name:, force:)
+        def generate_graphs_for_authority(authority_name:)
           [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-            hash[action] = generate_12_month_graph(authority_name: authority_name, action: action, force: force)
+            hash[action] = generate_12_month_graph(authority_name: authority_name, action: action)
           end
         end
 
-        def generate_12_month_graph(authority_name:, action:, force:)
+        def generate_12_month_graph(authority_name:, action:)
+          # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
+          # or force was requested.  We still expire the cache and use ttl to catch race conditions.
           Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
-                            expires_in: QaServer::CacheExpiryService.cache_expiry,
-                            race_condition_ttl: 1.hour, force: force) do
-            QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - GENERATING monthly performance graphs")
+                            expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
             data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
             graphing_service.generate_monthly_graph(authority_name: authority_name, action: action, data: data)
             data
@@ -41,7 +44,15 @@ module QaServer
         end
 
         def cache_key_for_authority_action(authority_name:, action:)
-          "#{QaServer::CacheKeys::PERFORMANCE_GRAPH_MONTHLY_DATA}-#{authority_name}-#{action}"
+          "#{PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY}--#{authority_name}--#{action}"
+        end
+
+        def cache_key_for_force
+          "#{PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY}--force"
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
         end
     end
   end


### PR DESCRIPTION
also cleans up…
* include _CACHE_KEY in the name of cache key constants
* log generation of performance graphs once per time period