### PR TITLE
move caching of summary and historical data to cache_processors

### DIFF
--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -2,8 +2,10 @@
 # This module sets up the keys used to identify data in Rails.cache
 module QaServer
   module CacheKeys
-    RUN_SUMMARY_DATA_CACHE_KEY = "QaServer--CacheKeys--run_summary_data"
-    RUN_HISTORY_DATA_CACHE_KEY = "QaServer--CacheKeys--run_history_data"
+    SCENARIO_RUN_TEST_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_test_data"
+    SCENARIO_RUN_SUMMARY_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_summary_data"
+    SCENARIO_RUN_FAILURE_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_failure_data"
+    SCENARIO_RUN_HISTORY_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_history_data"
 
     PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
     PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"

--- a/app/cache_processors/qa_server/performance_daily_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_daily_graph_cache.rb
@@ -12,6 +12,7 @@ module QaServer
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
+      # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
         return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
         QaServer.config.monitor_logger.debug("(QaServer::PerformanceDailyGraphCache) - GENERATING daily performance graphs (force: #{force})")

--- a/app/cache_processors/qa_server/performance_hourly_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_hourly_graph_cache.rb
@@ -13,6 +13,7 @@ module QaServer
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 24 hours for :search, :fetch, and :all actions for each authority.
+      # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
         QaServer.config.monitor_logger.debug("(QaServer::PerformanceHourlyGraphCache) - GENERATING hourly performance graphs (force: #{force})")
         QaServer.config.performance_cache.write_all

--- a/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
@@ -12,6 +12,7 @@ module QaServer
       include QaServer::PerformanceHistoryDataKeys
 
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
+      # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
         return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
         QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - GENERATING monthly performance graphs (force: #{force})")

--- a/app/cache_processors/qa_server/scenario_history_cache.rb
+++ b/app/cache_processors/qa_server/scenario_history_cache.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# Maintain a cache of data for Authority Connection History table displayed on Monitor Status page
+module QaServer
+  class ScenarioHistoryCache
+    class_attribute :scenario_history_class
+    self.scenario_history_class = QaServer::ScenarioRunHistory
+
+    class << self
+      include QaServer::CacheKeys
+
+      # Get a summary of the number of days passing/failing for scenario runs during configured time period
+      # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
+      # @returns [Array<Hash>] count of days with passing/failing tests for each authority
+      # @example [auth_name, failing, passing]
+      #   { 'agrovoc' => { good: 31, bad: 2 },
+      #     'geonames_ld4l_cache' => { good: 32, bad: 1 } }
+      def historical_summary(force: false)
+        Rails.cache.fetch(cache_key_for_historical_data, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioHistoryCache) - CALCULATING HISTORY of scenario runs (force: force)")
+          scenario_history_class.historical_summary
+        end
+      end
+
+      private
+
+        def cache_key_for_historical_data
+          SCENARIO_RUN_HISTORY_DATA_CACHE_KEY
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
+        end
+    end
+  end
+end

--- a/app/cache_processors/qa_server/scenario_run_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_cache.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# Maintain a cache controlling the execution of scenario tests.
+module QaServer
+  class ScenarioRunCache
+    class << self
+      include QaServer::CacheKeys
+
+      # Run connection tests
+      def run_tests(force: false)
+        Rails.cache.fetch(cache_key_for_running_tests, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunCache) - KICKING OFF TEST RUN (force: #{force})")
+          QaServer::MonitorTestsJob.perform_later
+          "Test run initiated at #{QaServer::TimeService.current_time}"
+        end
+      end
+
+      private
+
+        def cache_key_for_running_tests
+          SCENARIO_RUN_TEST_DATA_CACHE_KEY
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
+        end
+    end
+  end
+end

--- a/app/cache_processors/qa_server/scenario_run_failures_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_failures_cache.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# Maintain a cache of failure data for scenario runs
+module QaServer
+  class ScenarioRunFailuresCache
+    class_attribute :scenario_history_class
+    self.scenario_history_class = QaServer::ScenarioRunHistory
+
+    class << self
+      include QaServer::CacheKeys
+
+      # Set of failures for a run
+      # @param run [QaServer::ScenarioRunRegistry]
+      # @returns [Array<Hash>] details for any failing scenarios in the run
+      # @example
+      #   [ { status: :bad,
+      #       authority_name: "geonames_ld4l_cache",
+      #       subauthority_name: "area",
+      #       service: "ld4l_cache",
+      #       action: "search",
+      #       url: "/qa/search/linked_data/geonames_ld4l_cache/area?q=France&maxRecords=4",
+      #       err_message: "Unable to connect to authority",
+      #       scenario_type: :connection
+      #       run_time: 11.2 },
+      #     { status: :unknown,
+      #       authority_name: "oclcfast_ld4l_cache",
+      #       subauthority_name: "Person",
+      #       service: "ld4l_cache",
+      #       action: "search",
+      #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/person?q=mark twain&maxRecords=4",
+      #       err_message: "Not enough search results returned",
+      #       scenario_type: :connection
+      #       run_time: 0.123 } ]
+      def failures_for_run(run:)
+        Rails.cache.fetch(cache_key_for_run_failures(run.id), expires_in: next_expiry, race_condition_ttl: 30.seconds) do
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunFailuresCache) - CALCULATING FAILURES for scenario run #{run.id}")
+          scenario_history_class.run_failures(run_id: run.id)
+        end
+      end
+
+      private
+
+        def cache_key_for_run_failures(id)
+          "#{SCENARIO_RUN_FAILURE_DATA_CACHE_KEY}--#{id}{"
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
+        end
+    end
+  end
+end

--- a/app/cache_processors/qa_server/scenario_run_summary_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_summary_cache.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# Maintain a cache of summary test data for scenario runs
+module QaServer
+  class ScenarioRunSummaryCache
+    class_attribute :scenario_history_class
+    self.scenario_history_class = QaServer::ScenarioRunHistory
+
+    class << self
+      include QaServer::CacheKeys
+
+      # Summary for a run
+      # @param run [QaServer::ScenarioRunRegistry]
+      # @returns [QaServer::ScenarioRunSummary] statistics on the requested run
+      # @example ScenarioRunSummary includes methods for accessing
+      #   * run_id           [Integer] e.g. 14
+      #   * run_dt_stamp     [ActiveSupport::TimeWithZone] e.g. Wed, 19 Feb 2020 16:01:07 UTC +00:00
+      #   * authority_count  [Integer] e.g. 22
+      #   * failing_authority_count [Integer] e.g. 1
+      #   * passing_scenario_count  [Integer] e.g. 156
+      #   * failing_scenario_count  [Integer] e.g. 3
+      #   * total_scenario_count    [Integer] e.g. 159
+      def summary_for_run(run:)
+        Rails.cache.fetch(cache_key_for_run_summary(run.id), expires_in: next_expiry, race_condition_ttl: 30.seconds) do
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunSummaryCache) - CALCULATING SUMMARY for scenario run #{run.id}")
+          scenario_history_class.run_summary(scenario_run: run)
+        end
+      end
+
+      private
+
+        def cache_key_for_run_summary(id)
+          "#{SCENARIO_RUN_SUMMARY_DATA_CACHE_KEY}--#{id}"
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
+        end
+    end
+  end
+end

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Provide access to the scenario_run_history database table which tracks scenario runs over time.
 module QaServer
-  class ScenarioRunHistory < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
+  class ScenarioRunHistory < ActiveRecord::Base
     self.table_name = 'scenario_run_history'
     belongs_to :scenario_run_registry
     enum scenario_type: [:connection, :accuracy, :performance], _suffix: :type
@@ -35,78 +35,27 @@ module QaServer
 
       # Get a summary of passing/failing tests for a run.
       # @param scenario_run [QaServer::ScenarioRunRegistry] the run on which to gather statistics
-      # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
       # @returns [QaServer::ScenarioRunSummary] statistics on the requested run
       # @example ScenarioRunSummary includes methods for accessing
-      #   * run_id: 14,
-      #   * run_dt_stamp:
-      #   * authority_count: 22,
-      #   * failing_authority_count: 1
-      #   * passing_scenario_count: 156,
-      #   * failing_scenario_count: 3,
-      #   * total_scenario_count: 159,
-      def run_summary(scenario_run:, force: false)
-        Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::CacheExpiryService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING summary of latest run - cache expired or refresh requested (force: #{force})")
-          status = status_counts_in_run(run_id: scenario_run.id)
-          summary_class.new(run_id: scenario_run.id,
-                            run_dt_stamp: scenario_run.dt_stamp,
-                            authority_count: authorities_in_run(run_id: scenario_run.id).count,
-                            failing_authority_count: authorities_with_failures_in_run(run_id: scenario_run.id).count,
-                            passing_scenario_count: status['good'],
-                            failing_scenario_count: status['bad'] + status['unknown'])
-        end
+      #   * run_id           [Integer] e.g. 14
+      #   * run_dt_stamp     [ActiveSupport::TimeWithZone] e.g. Wed, 19 Feb 2020 16:01:07 UTC +00:00
+      #   * authority_count  [Integer] e.g. 22
+      #   * failing_authority_count [Integer] e.g. 1
+      #   * passing_scenario_count  [Integer] e.g. 156
+      #   * failing_scenario_count  [Integer] e.g. 3
+      #   * total_scenario_count    [Integer] e.g. 159
+      def run_summary(scenario_run:)
+        status = status_counts_in_run(run_id: scenario_run.id)
+        summary_class.new(run_id: scenario_run.id,
+                          run_dt_stamp: scenario_run.dt_stamp,
+                          authority_count: authorities_in_run(run_id: scenario_run.id).count,
+                          failing_authority_count: authorities_with_failures_in_run(run_id: scenario_run.id).count,
+                          passing_scenario_count: status['good'],
+                          failing_scenario_count: status['bad'] + status['unknown'])
       end
-
-      # Get set of all scenario results for a run.
-      # @param run_id [Integer] the run on which to gather statistics
-      # @param authority_name [String] limit results to those for the authority with this name
-      # @param status [Array<Symbol> | Symbol] :good, :bad, :unknown, or any of these in an array to select multiple status
-      # @param url [String] limit results to a specific scenario URL
-      # @returns [Array<ScenarioRunHistory>] scenario details for all scenarios in the run
-      # @example
-      #   [ { status: :bad,
-      #       authority_name: "geonames_ld4l_cache",
-      #       subauthority_name: "area",
-      #       service: "ld4l_cache",
-      #       action: "search",
-      #       url: "/qa/search/linked_data/geonames_ld4l_cache/area?q=France&maxRecords=4",
-      #       err_message: "Unable to connect to authority",
-      #       scenario_type: :connection
-      #       run_time: 11.2 },
-      #     { status: :good,
-      #       authority_name: "oclcfast_ld4l_cache",
-      #       subauthority_name: "Organization",
-      #       service: "ld4l_cache",
-      #       action: "search",
-      #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/organization?q=mark twain&maxRecords=4",
-      #       err_message: "",
-      #       scenario_type: :connection
-      #       run_time: 0.131 },
-      #     { status: :unknown,
-      #       authority_name: "oclcfast_ld4l_cache",
-      #       subauthority_name: "Person",
-      #       service: "ld4l_cache",
-      #       action: "search",
-      #       url: "/qa/search/linked_data/oclcfast_ld4l_cache/person?q=mark twain&maxRecords=4",
-      #       err_message: "Not enough search results returned",
-      #       scenario_type: :connection
-      #       run_time: 0.123 } ]
-      # @deprecated Not used anywhere. Being removed.
-      def run_results(run_id:, authority_name: nil, status: nil, url: nil)
-        return [] unless run_id
-        where = {}
-        where[:scenario_run_registry_id] = run_id
-        where[:authority_name] = authority_name if authority_name.present?
-        where[:status] = status if status.present?
-        where[:url] = url if url.present?
-        QaServer::ScenarioRunHistory.where(where).to_a
-      end
-      deprecation_deprecate run_results: "Not used anywhere. Being removed."
 
       # Get set of failures for a run, if any.
       # @param run_id [Integer] the run on which to gather statistics
-      # @param force [Boolean] if true, forces cache to regenerate; otherwise, returns value from cache unless expired
       # @returns [Array<Hash>] scenario details for any failing scenarios in the run
       # @example
       #   [ { status: :bad,
@@ -127,29 +76,23 @@ module QaServer
       #       err_message: "Not enough search results returned",
       #       scenario_type: :connection
       #       run_time: 0.123 } ]
-      def run_failures(run_id:, force: false)
+      def run_failures(run_id:)
         return [] unless run_id
-        Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::CacheExpiryService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - finding failures in latest run - cache expired or refresh requested (force: #{force})")
-          QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: :good).to_a
-        end
+        QaServer::ScenarioRunHistory.where(scenario_run_registry_id: run_id).where.not(status: :good).to_a
       end
 
-      # Get a summary level of historical data
-      # @returns [Array<Array>] summary of passing/failing tests for each authority
+      # Get a summary of the number of days passing/failing for scenario runs during configured time period
+      # @returns [Array<Hash>] count of days with passing/failing tests for each authority
       # @example [auth_name, failing, passing]
       #   { 'agrovoc' => { good: 31, bad: 2 },
       #     'geonames_ld4l_cache' => { good: 32, bad: 1 } }
-      def historical_summary(force: false)
-        Rails.cache.fetch("QaServer::ScenarioRunHistory/#{__method__}", expires_in: QaServer::CacheExpiryService.cache_expiry, race_condition_ttl: 1.minute, force: force) do
-          QaServer.config.monitor_logger.debug("(QaServer::ScenarioRunHistory##{__method__}) - CALCULATING authority connection history - cache expired or refresh requested (force: #{force})")
-          days_good = count_days(:good)
-          days_bad = count_days(:bad)
-          days_unknown = count_days(:unknown)
-          keys = (days_good.keys + days_bad.keys + days_unknown.keys).uniq.sort
-          keys.each_with_object({}) do |auth, hash|
-            hash[auth] = { good: day_count(auth, days_good), bad: day_count(auth, days_bad) + day_count(auth, days_unknown) }
-          end
+      def historical_summary
+        days_good = count_days(:good)
+        days_bad = count_days(:bad)
+        days_unknown = count_days(:unknown)
+        keys = (days_good.keys + days_bad.keys + days_unknown.keys).uniq.sort
+        keys.each_with_object({}) do |auth, hash|
+          hash[auth] = { good: day_count(auth, days_good), bad: day_count(auth, days_bad) + day_count(auth, days_unknown) }
         end
       end
 


### PR DESCRIPTION
includes caching for...
* scenario run summary
* scenario run failures
* scenario history
* running of connection tests controlled by cache time marker

also cleans up…
* yardoc missing for force parameter
* removed deprecated #run_results