### PR TITLE
release 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 7.0.0 (2020-02-19)
+
+* refactor of caching system to simplify the process
+  * rename monitor_cache_service to cache_expiry_service
+  * move generation of hourly graph to cache_processors
+  * move generation of daily and monthly graphs to cache_processors
+  * move performance datatable cache control to cache_processors
+  * move caching of summary and historical data to cache_processors
+  * move caching of test execution marker to cache_processors
+  * move performance cache of performance data to cache_processors
+  
 ### 6.2.0 (2020-02-17)
 
 * use authentication for refreshing monitor tests

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '6.2.0'
+  VERSION = '7.0.0'
 end


### PR DESCRIPTION
* refactor of caching system to simplify the process
* rename monitor_cache_service to cache_expiry_service
* move generation of hourly graph to cache_processors
* move generation of daily and monthly graphs to cache_processors
* move performance datatable cache control to cache_processors
* move caching of summary and historical data to cache_processors
* move caching of test execution marker to cache_processors
* move performance cache of performance data to cache_processors