### PR TITLE
move generation of history graph

### DIFF
--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -6,6 +6,7 @@ module QaServer
     SCENARIO_RUN_SUMMARY_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_summary_data"
     SCENARIO_RUN_FAILURE_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_failure_data"
     SCENARIO_RUN_HISTORY_DATA_CACHE_KEY = "QaServer--CacheKeys--scenario_run_history_data"
+    SCENARIO_RUN_HISTORY_GRAPH_CACHE_KEY = "QaServer--CacheKeys--scenario_run_history_graph"
 
     PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
     PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"

--- a/app/cache_processors/qa_server/scenario_history_cache.rb
+++ b/app/cache_processors/qa_server/scenario_history_cache.rb
@@ -16,7 +16,7 @@ module QaServer
       #     'geonames_ld4l_cache' => { good: 32, bad: 1 } }
       def historical_summary(force: false)
         Rails.cache.fetch(cache_key_for_historical_data, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
-          QaServer.config.monitor_logger.debug("(QaServer::ScenarioHistoryCache) - CALCULATING HISTORY of scenario runs (force: force)")
+          QaServer.config.monitor_logger.debug("(QaServer::ScenarioHistoryCache) - CALCULATING HISTORY of scenario runs (force: #{force})")
           scenario_history_class.historical_summary
         end
       end

--- a/app/cache_processors/qa_server/scenario_history_graph_cache.rb
+++ b/app/cache_processors/qa_server/scenario_history_graph_cache.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+# Generate graphs for the past 30 days using cached data.  Graphs are generated only if the cache has expired.
+module QaServer
+  class ScenarioHistoryGraphCache
+    class_attribute :graphing_service
+    self.graphing_service = QaServer::HistoryGraphingService
+
+    class << self
+      include QaServer::CacheKeys
+      include QaServer::MonitorStatus::GruffGraph
+
+      HISTORICAL_GRAPH_FILENAME = 'historical_side_stacked_bar.png'
+
+      # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
+      # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
+      def generate_graph(data:, force: false)
+        return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
+        QaServer.config.monitor_logger.debug("(QaServer::ScenarioHistoryGraphCache) - GENERATING historical summary graph (force: #{force})")
+        graphing_service.generate_graph(data)
+      end
+
+      private
+
+        def cache_key_for_force
+          "#{SCENARIO_RUN_HISTORY_GRAPH_CACHE_KEY}--force"
+        end
+
+        def next_expiry
+          QaServer::CacheExpiryService.cache_expiry
+        end
+    end
+  end
+end

--- a/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
@@ -96,17 +96,29 @@ module QaServer::MonitorStatus
 
       def performance_graphs_for_authority(graphs, auth_name)
         [:search, :fetch, :all_actions].each do |action|
-          graphs << performance_for_day_graph(auth_name, action)
-          graphs << performance_for_month_graph(auth_name, action)
-          graphs << performance_for_year_graph(auth_name, action)
+          day_graph = performance_for_day_graph(auth_name, action)
+          month_graph = performance_for_month_graph(auth_name, action)
+          year_graph = performance_for_year_graph(auth_name, action)
+          add_graphs(graphs, day_graph, month_graph, year_graph)
         end
       end
 
+      # only add the graphs if all 3 exist
+      def add_graphs(graphs, day_graph, month_graph, year_graph)
+        return unless day_graph[:exists] && month_graph[:exists] && year_graph[:exists]
+        graphs << day_graph
+        graphs << month_graph
+        graphs << year_graph
+      end
+
       def performance_for_day_graph(auth_name, action)
+        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :day)
+        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :day)
         {
           action: action,
           time_period: :day,
-          graph: QaServer::PerformanceGraphingService.performance_graph_file(authority_name: auth_name, action: action, time_period: :day),
+          graph: filepath,
+          exists: exists,
           label: "Performance data for the last 24 hours.",
           authority_name: auth_name,
           base_id: "performance-of-#{auth_name}"
@@ -114,10 +126,13 @@ module QaServer::MonitorStatus
       end
 
       def performance_for_month_graph(auth_name, action)
+        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :month)
+        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :month)
         {
           action: action,
           time_period: :month,
-          graph: QaServer::PerformanceGraphingService.performance_graph_file(authority_name: auth_name, action: action, time_period: :month),
+          graph: filepath,
+          exists: exists,
           label: "Performance data for the last 30 days.",
           authority_name: auth_name,
           base_id: "performance-of-#{auth_name}"
@@ -125,10 +140,13 @@ module QaServer::MonitorStatus
       end
 
       def performance_for_year_graph(auth_name, action)
+        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :year)
+        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :year)
         {
           action: action,
           time_period: :year,
-          graph: QaServer::PerformanceGraphingService.performance_graph_file(authority_name: auth_name, action: action, time_period: :year),
+          graph: filepath,
+          exists: exists,
           label: "Performance data for the last 12 months.",
           authority_name: auth_name,
           base_id: "performance-of-#{auth_name}"

--- a/app/presenters/qa_server/monitor_status/current_status_presenter.rb
+++ b/app/presenters/qa_server/monitor_status/current_status_presenter.rb
@@ -82,7 +82,7 @@ module QaServer::MonitorStatus
 
     # @return [Boolean] true if failure data exists for the latest test run; otherwise false
     def failures?
-      failing_tests_count.positive?
+      failing_tests_count.positive? && !failures.nil?
     end
   end
 end

--- a/app/presenters/qa_server/monitor_status/performance_presenter.rb
+++ b/app/presenters/qa_server/monitor_status/performance_presenter.rb
@@ -25,11 +25,11 @@ module QaServer::MonitorStatus
     end
 
     def display_performance_graph?
-      QaServer.config.display_performance_graph?
+      QaServer.config.display_performance_graph? && !performance_graphs.nil? && !performance_graphs.empty?
     end
 
     def display_performance_datatable?
-      QaServer.config.display_performance_datatable?
+      QaServer.config.display_performance_datatable? && !performance_data.nil?
     end
 
     def performance_data_authority_name(entry)

--- a/app/services/qa_server/history_graphing_service.rb
+++ b/app/services/qa_server/history_graphing_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+# This class sets creates the performance graphs for each authority during day, month, and year time periods for fetch and search actions.
+module QaServer
+  class HistoryGraphingService
+    class << self
+      include QaServer::MonitorStatus::GruffGraph
+
+      HISTORICAL_GRAPH_FILENAME = 'historical_side_stacked_bar.png'
+
+      class_attribute :authority_list_class
+      self.authority_list_class = QaServer::AuthorityListerService
+
+      # Path to use with <image> tags
+      def history_graph_image_path
+        historical_graph_relative_path
+      end
+
+      # @return [Boolean] true if image for graph exists; otherwise, false
+      def history_graph_image_exists?
+        File.exist? historical_graph_full_path
+      end
+
+      # Generate the graph of historical data
+      # @param data [Hash] data to use to generate the graph
+      # @see QaServer::ScenarioHistoricalCache.historical_summary for source of data
+      def generate_graph(data)
+        gruff_data = rework_historical_data_for_gruff(data)
+        create_gruff_graph(gruff_data, historical_graph_full_path)
+        QaServer.config.monitor_logger.warn("FAILED to write historical graph at #{history_graph_image_path}") unless history_graph_image_exists?
+      end
+
+      private
+
+        def create_gruff_graph(reworked_data, full_path)
+          g = Gruff::SideStackedBar.new
+          historical_graph_theme(g)
+          g.labels = reworked_data[0]
+          g.data('Fail', reworked_data[1])
+          g.data('Pass', reworked_data[2])
+          g.write full_path
+        end
+
+        def historical_graph_theme(g)
+          g.theme_pastel
+          g.colors = ['#ffcccc', '#ccffcc']
+          g.marker_font_size = 12
+          g.x_axis_increment = 10
+        end
+
+        def historical_graph_full_path
+          graph_full_path(HISTORICAL_GRAPH_FILENAME)
+        end
+
+        def historical_graph_relative_path
+          File.join(graph_relative_path, HISTORICAL_GRAPH_FILENAME)
+        end
+
+        def rework_historical_data_for_gruff(data)
+          labels = {}
+          pass_data = []
+          fail_data = []
+          i = 0
+          data.each do |authname, authdata|
+            labels[i] = authname
+            i += 1
+            fail_data << authdata[:bad]
+            pass_data << authdata[:good]
+          end
+          [labels, fail_data, pass_data]
+        end
+    end
+  end
+end

--- a/app/views/qa_server/monitor_status/_performance.html.erb
+++ b/app/views/qa_server/monitor_status/_performance.html.erb
@@ -2,7 +2,7 @@
     <div id="performance-data" class="status-section">
       <h3><%= t('qa_server.monitor_status.performance.title') %></h3>
 
-  <% if @presenter.display_performance_graph? && !@presenter.performance_graphs.nil? %>
+  <% if @presenter.display_performance_graph? %>
       <script>
         function switch_performance_view(base_id, time_period, action) {
           document.getElementById(base_id+'<%= @presenter.performance_graph_data_section_id(action: :all_actions, time_period: :day) %>').className = 'performance-data-section-hidden';
@@ -81,7 +81,7 @@
     </div>
   <% end %>
 
-  <% if @presenter.display_performance_datatable? && !@presenter.performance_data.nil? %>
+  <% if @presenter.display_performance_datatable? %>
     <div id="performance-datatable-section">
       <h4><%= t('qa_server.monitor_status.performance.datatable_desc') %></h4>
       <p class="status-update-dtstamp"><%= t('qa_server.monitor_status.performance.datarange', from: @presenter.performance_data_start, to: @presenter.performance_data_end) %></p>

--- a/app/views/qa_server/monitor_status/_test_history.html.erb
+++ b/app/views/qa_server/monitor_status/_test_history.html.erb
@@ -6,7 +6,7 @@
           <%= image_tag(@presenter.historical_graph, alt: 'History Graph Unavailable') %>
         <% end %>
 
-        <% if @presenter.display_historical_datatable? && !@presenter.historical_summary.nil? %>
+        <% if @presenter.display_historical_datatable? %>
           <table class="status">
             <tr>
               <th><%= t('qa_server.monitor_status.history.authority') %></th>

--- a/app/views/qa_server/monitor_status/_test_summary.html.erb
+++ b/app/views/qa_server/monitor_status/_test_summary.html.erb
@@ -19,7 +19,7 @@
   </table>
   <p class="status-update-dtstamp"><%= t('qa_server.monitor_status.summary.last_updated', date: @presenter.last_updated) %></p>
 
-  <% if @presenter.failures? & !@presenter.failures.nil? %>
+  <% if @presenter.failures?%>
     <div id="failures" class="status-section">
       <h4><%= t('qa_server.monitor_status.failures.title') %></h4>
 


### PR DESCRIPTION
* created history_graph_service to generate the graph
* created scenario_history_cache to cache the generation of the graph

Also cleanup…
* performance_grarphing_service uses same method names as history_graphing_service
* log warning in monitor logger if graph failed to create
* monitor_status page won’t try to display graphs if the graph files do not exist
* move checks for missing data from views to presenters