### PR TITLE
write out cache after completing monitor tests run

### DIFF
--- a/app/cache_processors/qa_server/performance_cache.rb
+++ b/app/cache_processors/qa_server/performance_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 # Model to hold performance data in memory and ultimately write it out to the database
+require 'objspace'
+
 module QaServer
   class PerformanceCache
     def initialize

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -26,6 +26,7 @@ module QaServer
         log_results(authorities_list, status_log.to_a)
         scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
         QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
+        QaServer.config.performance_cache.write_all # write out cache after completing tests
         reset_monitor_tests_job_id
       end
 


### PR DESCRIPTION
The normal processing is for the monitoring tests to run once per day.  The rest of the time cached data is used to display the monitor status page.

A side effect of running the tests is that a large amount of performance data is saved in the performance cache.  This PR writes out the performance cache and starts fresh with an empty cache.