### PR TITLE
release 7.2.1 - fix graph fails to display when text is empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.2.1 (2020-02-23)
+
+* fix graph fails generation when any label is empty string
+
 ### 7.2.0 (2020-02-22)
 
 * move graphs from assets to public directory

--- a/app/services/qa_server/performance_graph_data_service.rb
+++ b/app/services/qa_server/performance_graph_data_service.rb
@@ -103,7 +103,7 @@ module QaServer
           elsif ((idx + 1) % 2).zero?
             (start_hour.hour * 100).to_s
           else
-            ""
+            " "
           end
         end
 
@@ -113,7 +113,7 @@ module QaServer
           elsif ((idx + 1) % 5).zero?
             start_day.strftime("%m-%d")
           else
-            ""
+            " "
           end
         end
 

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '7.2.0'
+  VERSION = '7.2.1'
 end


### PR DESCRIPTION
Making text 1 blank character fixes the problem.