### PR TITLE
move job id cache to sepearate cache class

### DIFF
--- a/app/cache_processors/qa_server/job_id_cache.rb
+++ b/app/cache_processors/qa_server/job_id_cache.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# Provide service methods for getting a list of all authorities and scenarios for an authority.
+module QaServer
+  class JobIdCache
+    class << self
+      # Is the passed in job_id the active one for the job_key?
+      # @param job_key [String] key unique to the job being run (e.g. "QaServer::Jobs::MonitorTestsJob")
+      # @param job_id [String] UUID for job running the tests
+      # @param expires_in [ActiveSupport::Duration]  This should be at least as long as the expected job run time to avoid multiple instances of the job running at the same time.
+      # @note When job completes, call reset_job_id to invalidate the cache
+      def active_job_id?(job_key:, job_id:, expires_in: 30.minutes)
+        cached_job_id = Rails.cache.fetch(cache_key(job_key), expires_in: expires_in, race_condition_ttl: 5.minutes) { job_id }
+        cached_job_id == job_id
+      end
+
+      # Delete cache for job id for the job represented by job_key.  Call this when the job completes.
+      # @param job_key [String] key unique to the job being run (e.g. "QaServer::Jobs::MonitorTestsJob")
+      def reset_job_id(job_key:)
+        Rails.cache.delete(cache_key(job_key))
+      end
+
+      private
+
+        def cache_key(job_key)
+          "#{job_key}-job_id"
+        end
+    end
+  end
+end

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -11,9 +11,7 @@ module QaServer
 
     def perform
       Rails.cache.fetch("QaServer::MonitorStatusController/latest_test_run_from_cache", expires_in: QaServer::CacheExpiryService.cache_expiry, race_condition_ttl: 5.minutes, force: true) do
-        job_id = SecureRandom.uuid
-        monitor_tests_job_id = job_id unless monitor_tests_job_id
-        run_tests if monitor_tests_job_id == job_id # avoid race conditions
+        run_tests if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id, expires_in: 2.hours)
         scenario_run_registry_class.latest_run
       end
     end
@@ -27,32 +25,16 @@ module QaServer
         scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
         QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
         QaServer.config.performance_cache.write_all # write out cache after completing tests
-        reset_monitor_tests_job_id
-      end
-
-      # @return [String, Boolean] Returns job id of the job currently running tests; otherwise, false if tests are not running
-      def monitor_tests_job_id
-        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 5.minutes) { false }
-      end
-
-      # Set the id of the job that will run the tests.
-      # @param job_id [String] UUID for job running the tests
-      def monitor_tests_job_id=(job_id)
-        # check to see if there is a current job already running tests
-        current_job_id = Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 5.seconds) { job_id }
-
-        # current_job_id may be false meaning tests are not currently running; in which case, it is ok to force set job_id
-        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 30.seconds, force: true) { job_id } unless current_job_id
-      end
-
-      # Set job id for monitor tests to false indicating that tests are not currently running
-      def reset_monitor_tests_job_id
-        Rails.cache.fetch("QaServer:monitor_tests-job_id", expires_in: 2.hours, race_condition_ttl: 30.seconds, force: true) { false }
+        QaServer::JobIdCache.reset_job_id(job_key: job_key)
       end
 
       def log_results(authorities_list, results)
         QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) authorities_list is empty") if authorities_list&.empty?
         QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) test results are empty") if results&.empty?
+      end
+
+      def job_key
+        "QaServer::MonitorTestsJob--job_id"
       end
   end
 end

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -10,10 +10,8 @@ module QaServer
     self.scenario_run_registry_class = QaServer::ScenarioRunRegistry
 
     def perform
-      Rails.cache.fetch("QaServer::MonitorStatusController/latest_test_run_from_cache", expires_in: QaServer::CacheExpiryService.cache_expiry, race_condition_ttl: 5.minutes, force: true) do
-        run_tests if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id, expires_in: 2.hours)
-        scenario_run_registry_class.latest_run
-      end
+      # checking active_job_id? prevents race conditions for long running jobs
+      run_tests if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id, expires_in: 2.hours)
     end
 
     private


### PR DESCRIPTION
Justification: follow single responsibility principle

Prepare for reuse in graph jobs.