### PR TITLE
move performance year graph generation to background job

### DIFF
--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -9,6 +9,5 @@ module QaServer
     PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
     PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"
     PERFORMANCE_GRAPH_DAILY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_daily_data"
-    PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_monthly_data"
   end
 end

--- a/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_monthly_graph_cache.rb
@@ -2,54 +2,21 @@
 # Generate graphs for the past 12 months using cached data.  Graphs are generated only if the cache has expired.
 module QaServer
   class PerformanceMonthlyGraphCache
-    class_attribute :authority_list_class, :graph_data_service, :graphing_service
-    self.authority_list_class = QaServer::AuthorityListerService
-    self.graph_data_service = QaServer::PerformanceGraphDataService
-    self.graphing_service = QaServer::PerformanceGraphingService
-
     class << self
-      include QaServer::CacheKeys
-      include QaServer::PerformanceHistoryDataKeys
-
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
       # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
-        return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
-        QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - GENERATING monthly performance graphs (force: #{force})")
-        generate_graphs_for_authorities
+        Rails.cache.fetch(cache_key, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
+          QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - KICKING OFF PERFORMANCE MONTHLY GRAPH GENERATION (force: #{force})")
+          QaServer::PerformanceMonthlyGraphJob.perform_later
+          "Graphs generation initiated at #{QaServer::TimeService.current_time}"
+        end
       end
 
       private
 
-        def generate_graphs_for_authorities
-          auths = authority_list_class.authorities_list
-          generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
-          auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        end
-
-        def generate_graphs_for_authority(authority_name:)
-          [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-            hash[action] = generate_12_month_graph(authority_name: authority_name, action: action)
-          end
-        end
-
-        def generate_12_month_graph(authority_name:, action:)
-          # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
-          # or force was requested.  We still expire the cache and use ttl to catch race conditions.
-          Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
-                            expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
-            data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
-            graphing_service.generate_monthly_graph(authority_name: authority_name, action: action, data: data)
-            data
-          end
-        end
-
-        def cache_key_for_authority_action(authority_name:, action:)
-          "#{PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY}--#{authority_name}--#{action}"
-        end
-
-        def cache_key_for_force
-          "#{PERFORMANCE_GRAPH_MONTHLY_DATA_CACHE_KEY}--force"
+        def cache_key
+          "QaServer::PerformanceMonthlyGraphCache.generate_graphs--latest_generation_initiated"
         end
 
         def next_expiry

--- a/app/cache_processors/qa_server/performance_year_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_year_graph_cache.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 # Generate graphs for the past 12 months using cached data.  Graphs are generated only if the cache has expired.
 module QaServer
-  class PerformanceMonthlyGraphCache
+  class PerformanceYearGraphCache
     class << self
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
       # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
         Rails.cache.fetch(cache_key, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
-          QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthlyGraphCache) - KICKING OFF PERFORMANCE MONTHLY GRAPH GENERATION (force: #{force})")
-          QaServer::PerformanceMonthlyGraphJob.perform_later
+          QaServer.config.monitor_logger.debug("(QaServer::PerformanceYearGraphCache) - KICKING OFF PERFORMANCE YEAR GRAPH GENERATION (force: #{force})")
+          QaServer::PerformanceYearGraphJob.perform_later
           "Graphs generation initiated at #{QaServer::TimeService.current_time}"
         end
       end
@@ -16,7 +16,7 @@ module QaServer
       private
 
         def cache_key
-          "QaServer::PerformanceMonthlyGraphCache.generate_graphs--latest_generation_initiated"
+          "QaServer::PerformanceYearGraphCache.generate_graphs--latest_generation_initiated"
         end
 
         def next_expiry

--- a/app/controllers/qa_server/monitor_status_controller.rb
+++ b/app/controllers/qa_server/monitor_status_controller.rb
@@ -73,7 +73,7 @@ module QaServer
         return unless QaServer.config.display_performance_graph?
         QaServer::PerformanceHourlyGraphCache.generate_graphs(force: refresh_performance_graphs?)
         QaServer::PerformanceDailyGraphCache.generate_graphs(force: refresh_performance_graphs?)
-        QaServer::PerformanceMonthlyGraphCache.generate_graphs(force: refresh_performance_graphs?)
+        QaServer::PerformanceYearGraphCache.generate_graphs(force: refresh_performance_graphs?)
       end
 
       def refresh?

--- a/app/jobs/qa_server/performance_monthly_graph_job.rb
+++ b/app/jobs/qa_server/performance_monthly_graph_job.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+# Job to run monitoring tests
+module QaServer
+  class PerformanceMonthlyGraphJob < ApplicationJob
+    include QaServer::PerformanceHistoryDataKeys
+
+    queue_as :default
+
+    class_attribute :authority_list_class, :graph_data_service, :graphing_service
+    self.authority_list_class = QaServer::AuthorityListerService
+    self.graph_data_service = QaServer::PerformanceGraphDataService
+    self.graphing_service = QaServer::PerformanceGraphingService
+
+    def perform
+      # checking active_job_id? prevents race conditions for long running jobs
+      generate_graphs_for_authorities if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
+    end
+
+    private
+
+      def generate_graphs_for_authorities
+        auths = authority_list_class.authorities_list
+        generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+        auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
+      end
+
+      def generate_graphs_for_authority(authority_name:)
+        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+          hash[action] = generate_12_month_graph(authority_name: authority_name, action: action)
+        end
+      end
+
+      def generate_12_month_graph(authority_name:, action:)
+        # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
+        # or force was requested.  We still expire the cache and use ttl to catch race conditions.
+        Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
+                          expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
+          data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
+          graphing_service.generate_monthly_graph(authority_name: authority_name, action: action, data: data)
+          data
+        end
+      end
+
+      def job_key
+        "QaServer::PerformanceMonthlyGraphJob--job_id"
+      end
+
+      def cache_key_for_authority_action(authority_name:, action:)
+        "QaServer::PerformanceMonthlyGraphJob--data--#{authority_name}--#{action}"
+      end
+  end
+end

--- a/app/jobs/qa_server/performance_year_graph_job.rb
+++ b/app/jobs/qa_server/performance_year_graph_job.rb
@@ -19,11 +19,11 @@ module QaServer
     private
 
       def generate_graphs_for_authorities
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) - GENERATING performance year graph")
+        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance year graph")
         auths = authority_list_class.authorities_list
         generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
         auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED performance year graph generation")
+        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance year graph generation")
       end
 
       def generate_graphs_for_authority(authority_name:)
@@ -33,22 +33,13 @@ module QaServer
       end
 
       def generate_12_month_graph(authority_name:, action:)
-        # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
-        # or force was requested.  We still expire the cache and use ttl to catch race conditions.
-        Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
-                          expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
-          data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
-          graphing_service.generate_year_graph(authority_name: authority_name, action: action, data: data)
-          data
-        end
+        data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
+        graphing_service.generate_year_graph(authority_name: authority_name, action: action, data: data)
+        data
       end
 
       def job_key
         "QaServer::PerformanceYearGraphJob--job_id"
-      end
-
-      def cache_key_for_authority_action(authority_name:, action:)
-        "QaServer::PerformanceYearGraphJob--data--#{authority_name}--#{action}"
       end
   end
 end

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -31,7 +31,7 @@ module QaServer
       # @param action [Symbol] action performed by the request (e.g. :search, :fetch, :all_actions)
       # @param data [Hash] data to use to generate the graph
       # @see QaServer::PerformanceGraphDataService.calculate_last_12_months
-      def generate_monthly_graph(authority_name: ALL_AUTH, action:, data:)
+      def generate_year_graph(authority_name: ALL_AUTH, action:, data:)
         gruff_data = rework_performance_data_for_gruff(data, BY_MONTH)
         create_gruff_graph(gruff_data,
                            performance_graph_full_path(authority_name, action, FOR_YEAR),


### PR DESCRIPTION
* moves graph generation to background job
* renames monthly to year to avoid confusion with month graph
* remove cache of performance year graph data

RE: cache removal - Now that the kickoff of the graph generation process is cached and calls the performance year graph job when expired, the cache of the data is no longer needed.  Everytime the job is executed, the data will need to be generated.  There is a cache of the job_id to prevent race conditions.