### PR TITLE
move performance month graph generation to background job

### DIFF
--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -8,6 +8,5 @@ module QaServer
 
     PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
     PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"
-    PERFORMANCE_GRAPH_MONTH_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_month_data"
   end
 end

--- a/app/cache_processors/concerns/qa_server/cache_keys.rb
+++ b/app/cache_processors/concerns/qa_server/cache_keys.rb
@@ -8,6 +8,6 @@ module QaServer
 
     PERFORMANCE_DATATABLE_DATA_CACHE_KEY = "QaServer--Cache--performance_datatable_data"
     PERFORMANCE_GRAPH_HOURLY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_hourly_data"
-    PERFORMANCE_GRAPH_DAILY_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_daily_data"
+    PERFORMANCE_GRAPH_MONTH_DATA_CACHE_KEY = "QaServer--CacheKeys--performance_graph_month_data"
   end
 end

--- a/app/cache_processors/qa_server/performance_month_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_month_graph_cache.rb
@@ -1,55 +1,22 @@
 # frozen_string_literal: true
-# Generate graphs for the past 30 days using cached data.  Graphs are generated only if the cache has expired.
+# Cache the datetime_stamp of the last time the performance month graph was generated.  Calls job to generate the graph if expired.
 module QaServer
   class PerformanceMonthGraphCache
-    class_attribute :authority_list_class, :graph_data_service, :graphing_service
-    self.authority_list_class = QaServer::AuthorityListerService
-    self.graph_data_service = QaServer::PerformanceGraphDataService
-    self.graphing_service = QaServer::PerformanceGraphingService
-
     class << self
-      include QaServer::CacheKeys
-      include QaServer::PerformanceHistoryDataKeys
-
       # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
       # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
-        return unless QaServer::CacheExpiryService.cache_expired?(key: cache_key_for_force, force: force, next_expiry: next_expiry)
-        QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthGraphCache) - GENERATING performance month graphs (force: #{force})")
-        generate_graphs_for_authorities
+        Rails.cache.fetch(cache_key, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do
+          QaServer.config.monitor_logger.debug("(QaServer::PerformanceMonthGraphCache) - KICKING OFF PERFORMANCE MONTH GRAPH GENERATION (force: #{force})")
+          QaServer::PerformanceMonthGraphJob.perform_later
+          "Graphs generation initiated at #{QaServer::TimeService.current_time}"
+        end
       end
 
       private
 
-        def generate_graphs_for_authorities
-          auths = authority_list_class.authorities_list
-          generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
-          auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        end
-
-        def generate_graphs_for_authority(authority_name:)
-          [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-            hash[action] = generate_30_day_graph(authority_name: authority_name, action: action)
-          end
-        end
-
-        def generate_30_day_graph(authority_name:, action:)
-          # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
-          # or force was requested.  We still expire the cache and use ttl to catch race conditions.
-          Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
-                            expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
-            data = graph_data_service.calculate_last_30_days(authority_name: authority_name, action: action)
-            graphing_service.generate_month_graph(authority_name: authority_name, action: action, data: data)
-            data
-          end
-        end
-
-        def cache_key_for_authority_action(authority_name:, action:)
-          "#{PERFORMANCE_GRAPH_MONTH_DATA_CACHE_KEY}--#{authority_name}--#{action}"
-        end
-
-        def cache_key_for_force
-          "#{PERFORMANCE_GRAPH_MONTH_DATA_CACHE_KEY}--force"
+        def cache_key
+          "QaServer::PerformanceMonthGraphCache.generate_graphs--latest_generation_initiated"
         end
 
         def next_expiry

--- a/app/cache_processors/qa_server/performance_year_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_year_graph_cache.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-# Generate graphs for the past 12 months using cached data.  Graphs are generated only if the cache has expired.
+# Cache the datetime_stamp of the last time the performance year graph was generated.  Calls job to generate the graph if expired.
 module QaServer
   class PerformanceYearGraphCache
     class << self
-      # Generates graphs for the past 30 days for :search, :fetch, and :all actions for each authority.
+      # Generates graphs for the 12 months for :search, :fetch, and :all actions for each authority.
       # @param force [Boolean] if true, run the tests even if the cache hasn't expired; otherwise, use cache if not expired
       def generate_graphs(force: false)
         Rails.cache.fetch(cache_key, expires_in: next_expiry, race_condition_ttl: 30.seconds, force: force) do

--- a/app/controllers/qa_server/monitor_status_controller.rb
+++ b/app/controllers/qa_server/monitor_status_controller.rb
@@ -72,7 +72,7 @@ module QaServer
       def update_performance_graphs
         return unless QaServer.config.display_performance_graph?
         QaServer::PerformanceHourlyGraphCache.generate_graphs(force: refresh_performance_graphs?)
-        QaServer::PerformanceDailyGraphCache.generate_graphs(force: refresh_performance_graphs?)
+        QaServer::PerformanceMonthGraphCache.generate_graphs(force: refresh_performance_graphs?)
         QaServer::PerformanceYearGraphCache.generate_graphs(force: refresh_performance_graphs?)
       end
 

--- a/app/jobs/qa_server/history_graph_job.rb
+++ b/app/jobs/qa_server/history_graph_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# Job to run monitoring tests
+# Job to generate the graph of historical test runs per authority.
 module QaServer
   class HistoryGraphJob < ApplicationJob
     queue_as :default

--- a/app/jobs/qa_server/performance_month_graph_job.rb
+++ b/app/jobs/qa_server/performance_month_graph_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# Job to generate the performance month graph covering the last 30 days.
+module QaServer
+  class PerformanceMonthGraphJob < ApplicationJob
+    include QaServer::PerformanceHistoryDataKeys
+
+    queue_as :default
+
+    class_attribute :authority_list_class, :graph_data_service, :graphing_service
+    self.authority_list_class = QaServer::AuthorityListerService
+    self.graph_data_service = QaServer::PerformanceGraphDataService
+    self.graphing_service = QaServer::PerformanceGraphingService
+
+    def perform
+      # checking active_job_id? prevents race conditions for long running jobs
+      generate_graphs_for_authorities if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
+    end
+
+    private
+
+      def generate_graphs_for_authorities
+        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance month graph")
+        auths = authority_list_class.authorities_list
+        generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+        auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
+        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance month graph generation")
+      end
+
+      def generate_graphs_for_authority(authority_name:)
+        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+          hash[action] = generate_30_day_graph(authority_name: authority_name, action: action)
+        end
+      end
+
+      def generate_30_day_graph(authority_name:, action:)
+        # real expiration or force caught by cache_expired?  So if we are here, either the cache has expired
+        # or force was requested.  We still expire the cache and use ttl to catch race conditions.
+        Rails.cache.fetch(cache_key_for_authority_action(authority_name: authority_name, action: action),
+                          expires_in: next_expiry, race_condition_ttl: 1.hour, force: true) do
+          data = graph_data_service.calculate_last_30_days(authority_name: authority_name, action: action)
+          graphing_service.generate_month_graph(authority_name: authority_name, action: action, data: data)
+          data
+        end
+      end
+
+      def job_key
+        "QaServer::PerformanceMonthGraphJob--job_id"
+      end
+  end
+end

--- a/app/jobs/qa_server/performance_year_graph_job.rb
+++ b/app/jobs/qa_server/performance_year_graph_job.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# Job to run monitoring tests
+# Job to generate the performance year graph covering the last 12 months.
 module QaServer
   class PerformanceYearGraphJob < ApplicationJob
     include QaServer::PerformanceHistoryDataKeys

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -44,7 +44,7 @@ module QaServer
       # @param action [Symbol] action performed by the request (e.g. :search, :fetch, :all_actions)
       # @param data [Hash] data to use to generate the graph
       # @see QaServer::PerformanceGraphDataService.calculate_last_30_days
-      def generate_daily_graph(authority_name: ALL_AUTH, action:, data:)
+      def generate_month_graph(authority_name: ALL_AUTH, action:, data:)
         gruff_data = rework_performance_data_for_gruff(data, BY_DAY)
         create_gruff_graph(gruff_data,
                            performance_graph_full_path(authority_name, action, FOR_MONTH),


### PR DESCRIPTION
Also, rename daily to month to avoid confusion with day graph.

These are the same changes that were made for the year graph.  See PR #330.