### PR TITLE
Run accuracy tests with rspec for regression testing

### DIFF
--- a/app/loggers/qa_server/scenario_logger.rb
+++ b/app/loggers/qa_server/scenario_logger.rb
@@ -28,6 +28,7 @@ module QaServer
     # @option service [String] identifies the primary service provider (e.g. 'ld4l_cache', 'direct', etc.)
     # @option action [String] type of scenario (i.e. 'term', 'search')
     # @option url [String] example url that was used to test a specific term fetch or search query
+    # @option request_data [String] either the query for searches or the requested id/uri for fetch
     # @option error_message [String] error message if scenario failed
     # @option expected [Integer] the expected result (e.g. min size of result OR max position of subject within results)
     # @option actual [Integer] the actual result (e.g. actual size of results OR actual position of subject within results)
@@ -44,6 +45,7 @@ module QaServer
                 service: status_info[:service] || '',
                 action: status_info[:action] || '',
                 url: status_info[:url] || '',
+                request_data: status_info[:request_data] || '',
                 expected: status_info[:expected] || nil,
                 actual: status_info[:actual] || nil,
                 target: status_info[:target] || nil,

--- a/app/models/qa_server/authority_scenario.rb
+++ b/app/models/qa_server/authority_scenario.rb
@@ -5,13 +5,13 @@ module QaServer
     # @return [Qa::Authorities::LinkedData::GenericAuthority] authority instance the scenarios run against
     attr_reader :authority
 
-    # @return [String] name of the authority the scenarios run against (e.g. 'agrovoc_direct')
+    # @return [Symbol] name of the authority the scenarios run against (e.g. :AGROVOC_DIRECT)
     attr_reader :authority_name
 
     # @return [String] identifies the primary service provider (e.g. 'ld4l_cache', 'direct', etc.)
     attr_reader :service
 
-    # @return [String] name of the subauthority the scenario runs against
+    # @return [String] name of the subauthority the scenario runs against (e.g. 'person')
     attr_reader :subauthority_name
 
     # @return [Integer] the minimum size of data that must be returned for the scenario to be considered passing
@@ -21,14 +21,14 @@ module QaServer
     MIN_EXPECTED_SIZE = 200
 
     # @param authority [Qa::Authorities::LinkedData::GenericAuthority] the instance of the QA authority
-    # @param authoity_name [String] the name of the authority the scenario tests (e.g. "agrovoc_direct")
+    # @param authority_name [Symbol] the name of the authority the scenario tests (e.g. :AGROVOC_DIRECT)
     # @param authority_scenario_config [Hash] configurations from the yml file that pertain to all scenarios regardless of type
     # @param scenario_config [Hash] configuration from the yml file that are specific to a type of scenario
     def initialize(authority:, authority_name:, authority_scenario_config:, scenario_config: nil)
       @authority = authority
       @authority_name = authority_name
       @service = authority_scenario_config['service']
-      @context = authority_scenario_config.fetch('context', false)
+      @context = scenario_config.key?("position") ? false : authority_scenario_config.fetch('context', false)
       @subauthority_name = DEFAULT_SUBAUTH
       @min_result_size = MIN_EXPECTED_SIZE
     end

--- a/app/models/qa_server/search_scenario.rb
+++ b/app/models/qa_server/search_scenario.rb
@@ -20,7 +20,7 @@ module QaServer
     DEFAULT_SUBJECT_URI = nil
 
     # @param authority [Qa::Authorities::LinkedData::GenericAuthority] the instance of the QA authority
-    # @param authoity_name [Symbol] the name of the authority the scenario tests (e.g. :AGROVOC_DIRECT)
+    # @param authority_name [Symbol] the name of the authority the scenario tests (e.g. :AGROVOC_DIRECT)
     # @param authority_scenario_config [Hash] configurations from the yml file that pertain to all scenarios regardless of type
     # @param scenario_config [Hash] configuration from the yml file that are specific to a search scenario
     def initialize(authority:, authority_name:, authority_scenario_config:, scenario_config:)

--- a/app/validators/qa_server/scenario_validator.rb
+++ b/app/validators/qa_server/scenario_validator.rb
@@ -45,6 +45,7 @@ module QaServer
         status_info[:service] = service
         status_info[:action] = action
         status_info[:url] = url
+        status_info[:request_data] = request_data
         status_log.add(status_info)
       end
 
@@ -53,6 +54,10 @@ module QaServer
       end
 
       def run_connection_scenario
+        # ABSTRACT - must be implemented by scenario validator for specific types
+      end
+
+      def request_data
         # ABSTRACT - must be implemented by scenario validator for specific types
       end
 
@@ -71,26 +76,32 @@ module QaServer
         log(status: FAIL, error_message: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
       end
 
+      # @return [Qa::Authorities::LinkedData::GenericAuthority] authority instance the scenarios run against
       def authority
         scenario.authority
       end
 
+      # @return [Symbol] name of the authority (e.g. :CERL_LD4L_CACHE)
       def authority_name
         scenario.authority_name.upcase
       end
 
+      # @return [String] name of the subauthority (e.g. "person")
       def subauthority_name
         scenario.subauthority_name
       end
 
+      # @return [String] service providing the data (e.g. "ld4l_cache" or "direct")
       def service
         scenario.service
       end
 
+      # @return [String] relative URL with ready to execute (e.g. ""/authorities/search/linked_data/cerl_ld4l_cache/person?q=office")
       def url
         scenario.url
       end
 
+      # @return [String] action being tested (e.g. "search" or "term")
       def action
         # ABSTRACT - must be implemented by scenario validator for specific types
       end

--- a/app/validators/qa_server/search_scenario_validator.rb
+++ b/app/validators/qa_server/search_scenario_validator.rb
@@ -6,11 +6,16 @@ module QaServer
   class SearchScenarioValidator < ScenarioValidator
     SEARCH_ACTION = 'search'
 
+    # CONCRETE Implementation: Return value of request_data
+    attr_reader :request_data
+    private :request_data
+
     # @param scenario [SearchScenario] the scenario to run
     # @param status_log [ScenarioLogger] logger for recording test results
     # @param validation_type [Symbol] the type of scenarios to run (e.g. VALIDATE_CONNECTION, VALIDATE_ACCURACY, ALL_VALIDATIONS)
     def initialize(scenario:, status_log:, validation_type: DEFAULT_VALIDATION_TYPE)
       super
+      @request_data = scenario.query
     end
 
     private
@@ -19,7 +24,7 @@ module QaServer
         SEARCH_ACTION
       end
 
-      # Run the connection test and log results
+      # CONCRETE Implementation: Run the connection test and log results
       def run_connection_scenario
         test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'search') do
           replacements = scenario.replacements.dup
@@ -29,12 +34,13 @@ module QaServer
         end
       end
 
-      # Run the accuracy test and log results
+      # CONCRETE Implementation: Run the accuracy test and log results
       def run_accuracy_scenario
         test_accuracy(subject_uri: scenario.subject_uri, expected_by_position: scenario.expected_by_position) do
+          replacements = scenario.replacements.dup
           authority.search(scenario.query,
                            subauth: scenario.subauthority_name,
-                           replacements: scenario.replacements)
+                           replacements: replacements)
         end
       end
 

--- a/app/validators/qa_server/term_scenario_validator.rb
+++ b/app/validators/qa_server/term_scenario_validator.rb
@@ -4,27 +4,32 @@ module QaServer
   class TermScenarioValidator < ScenarioValidator
     TERM_ACTION = 'term'
 
+    # CONCRETE Implementation: Return value of request_data
+    attr_reader :request_data
+    private :request_data
+
     # @param scenario [TermScenario] the scenario to run
     # @param status_log [ScenarioLogger] logger for recording test results
     # @param validation_type [Symbol] the type of scenarios to run (e.g. VALIDATE_CONNECTION, VALIDATE_ACCURACY, ALL_VALIDATIONS)
     def initialize(scenario:, status_log:, validation_type: DEFAULT_VALIDATION_TYPE)
       super
-    end
-
-    # Run a term scenario and log results.
-    def run_connection_scenario
-      test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'term') do
-        authority.find(scenario.identifier,
-                       subauth: scenario.subauthority_name)
-      end
-    end
-
-    # Run a term scenario and log results.
-    def run_accuracy_scenario
-      # no accuracy scenarios defined for terms at this time
+      @request_data = scenario.identifier
     end
 
     private
+
+      # CONCRETE Implementation: Run a term scenario and log results.
+      def run_connection_scenario
+        test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'term') do
+          authority.find(scenario.identifier,
+                         subauth: scenario.subauthority_name)
+        end
+      end
+
+      # CONCRETE Implementation: Run a term scenario and log results.
+      def run_accuracy_scenario
+        # no accuracy scenarios defined for terms at this time
+      end
 
       def action
         TERM_ACTION

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
@@ -26,4 +26,3 @@ search:
 term:
   -
     identifier: 'http://dbpedia.org/resource/Barack_Obama'
-

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
@@ -31,7 +31,7 @@ search:
     replacements:
       maxRecords: '20'
   -
-    query: maps 
+    query: maps
     position: 3
     subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026387"
     replacements:

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -199,13 +199,17 @@ module QaServer
     # Performance data is gathered on every incoming query.  Basic stats are logged from QA.  Full stats are logged
     # by QaServer and can eat up logging realestate.  To suppress the logging of details, set this config to true.
     # @param [Boolean] do not log performance data details when true (defaults to false for backward compatibitily)
-    attr_writer :suppress_logging_performance_datails
-    def suppress_logging_performance_datails?
-      return @suppress_logging_performance_datails unless @suppress_logging_performance_datails.nil?
-      @suppress_logging_performance_datails ||= false
+    attr_writer :suppress_logging_performance_details
+    def suppress_logging_performance_details?
+      return @suppress_logging_performance_details unless @suppress_logging_performance_details.nil?
+      @suppress_logging_performance_details ||= false
     end
-    alias suppress_logging_performance_datails suppress_logging_performance_datails?
+    alias suppress_logging_performance_datails suppress_logging_performance_details?
+    alias suppress_logging_performance_datails? suppress_logging_performance_details?
+    alias suppress_logging_performance_datails= suppress_logging_performance_details=
     deprecation_deprecate suppress_logging_performance_datails: "use #suppress_logging_performance_datails? instead"
+    deprecation_deprecate suppress_logging_performance_datails?: "use #suppress_logging_performance_details? instead"
+    # deprecation_deprecate suppress_logging_performance_datails=: "use #suppress_logging_performance_details= instead"
 
     # Maximum amount of memory the performance cache can occupy before it is written to the database.
     # @param [Integer] maximum size of performance cache before flushing

--- a/spec/feature/accuracy_spec.rb
+++ b/spec/feature/accuracy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+# rubocop:disable RSpec/InstanceVariable
+RSpec.describe 'Accuracy test' do # rubocop:disable RSpec/DescribeClass
+  before(:all) { WebMock.allow_net_connect! }
+  after(:all) { WebMock.disable_net_connect! }
+
+  let(:authority_list) { QaServer::AuthorityListerService.authorities_list }
+  let(:authority_name) { :CERL_LD4L_CACHE }
+
+  describe 'for authority' do
+    @status_log = QaServer::ScenarioLogger.new
+    QaServer::AuthorityListerService.authorities_list.each do |authority_name| # rubocop:disable Style/MultilineIfModifier
+      QaServer::AuthorityValidatorService.run(authority_name: authority_name,
+                                              status_log: @status_log,
+                                              validation_type: QaServer::ScenarioValidator::VALIDATE_ACCURACY)
+    end unless ENV['TRAVIS']
+    @status_log.each do |test_result|
+      context "'#{test_result[:authority_name]}/#{test_result[:subauthority_name]}' with query '#{test_result[:request_data]}'" do
+        it "finds a result" do
+          expect(test_result[:actual]).not_to be_nil
+        end
+
+        it "finds actual <= expected" do
+          expect(test_result[:actual]).to be <= test_result[:expected]
+        end
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/InstanceVariable

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,3 +62,7 @@ def load_fixture_file(fname)
     return f.read
   end
 end
+
+QaServer.config.suppress_performance_gathering = true
+QaServer.config.suppress_logging_performance_details = true
+QaServer.config.preferred_time_zone_name = 'Eastern Time (US & Canada)'


### PR DESCRIPTION
Prevents accuracy tests from running in Travis as it is not uncommon for some tests to fail.  This is not a reflection on the functioning of the qa_server code.  It is an analysis of the ability of authority providers to accurately find resources.

This PR also includes...
* add request_data to status_logger (e.g. query for search , identifier for term)
* fix/add yardoc for data being passed in/returned
* deprecate mispelled methods (i.e. datails become details)
* set defaults for QaServer configs to not write out performance data and to set the time zone