### PR TITLE
Fixed URI and added one subauth test

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
@@ -70,14 +70,21 @@ search:
   -
     query: France
     subauth: area
-    subject_uri: 'http://sws.geonames.org/261707/'
+    subject_uri: "http://sws.geonames.org/3017382"
     position: 10
     replacements:
       maxRecords: '15'
   -
     query: Chicago
     subauth: place
-    subject_uri: 'http://sws.geonames.org/4887398/'
+    subject_uri: "http://sws.geonames.org/4887398/"
+    postion: 10
+    replacements:
+      maxRecords: '15'
+  -
+    query: Ithaca Island
+    subauth: terrain
+    subject_uri: "http://sws.geonames.org/261707/"
     postion: 10
     replacements:
       maxRecords: '15'


### PR DESCRIPTION
Not adding  a lot of subauth test right now. No profiles seem to be using this looking up and the geonames ontology isn't particularly easy to interpret with respect to Feature subclasses. Normalized syntax too.