### PR TITLE
add accuracy test for Tanaka, Shōzō

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -53,6 +53,27 @@ search:
     replacements:
       maxRecords: '20'
   -
+    query: Tanaka, Shōzō
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tanaka, Shozo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 田中正造
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
     query: ACLU
     subauth: organization
     position: 20


### PR DESCRIPTION
Adding tests for Issue #201

### Tests added for variants

* adds with diacritics
* adds without diacritics
* adds with name in Japanese

### Failing tests

#### using old indexing approach:
not found     LOCNAMES_RWO_LD4L_CACHE:person:Tanaka, Shozo
not found     LOCNAMES_RWO_LD4L_CACHE:person:Tanaka, Shōzō
not found     LOCNAMES_RWO_LD4L_CACHE:person:田中正造

#### using new indexing approach:
found at 12; expected by 5   LOCNAMES_RWO_W_LD4L_CACHE:person:Tanaka, Shōzō
