### PR TITLE
update to latest bixby for rubocop style checking

### DIFF
--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -13,8 +13,8 @@ Style/SpecialGlobalVars:
   Exclude:
     - 'tasks/qa_server_dev.rake'
 
-Layout/IndentationConsistency:
-  Enabled: false
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
 
-Layout/IndentationWidth:
-  Enabled: false
+#Layout/IndentationWidth:
+#  Enabled: false

--- a/.rubocop_fixme.yml
+++ b/.rubocop_fixme.yml
@@ -12,3 +12,9 @@ Lint/UnusedMethodArgument:
 Style/SpecialGlobalVars:
   Exclude:
     - 'tasks/qa_server_dev.rake'
+
+Layout/IndentationConsistency:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 Bundler::GemHelper.install_tasks
 
 # Set up the test application prior to running jasmine tasks.
-task :setup_test_server do
+task setup_test_server: :environment do
   require 'engine_cart'
   EngineCart.load_application!
 end

--- a/app/cache_processors/qa_server/cache_expiry_service.rb
+++ b/app/cache_processors/qa_server/cache_expiry_service.rb
@@ -24,15 +24,15 @@ module QaServer
         force
       end
 
-      private
+    private
 
-        # @return [ActiveSupport::TimeWithZone] DateTime at which cache should expire
-        def cache_expires_at
-          offset = QaServer.config.hour_offset_to_expire_cache
-          offset_time = QaServer::TimeService.current_time
-          offset_time = offset_time.tomorrow unless (offset_time + 5.minutes).hour < offset
-          offset_time.beginning_of_day + offset.hours - 5.minutes
-        end
+      # @return [ActiveSupport::TimeWithZone] DateTime at which cache should expire
+      def cache_expires_at
+        offset = QaServer.config.hour_offset_to_expire_cache
+        offset_time = QaServer::TimeService.current_time
+        offset_time = offset_time.tomorrow unless (offset_time + 5.minutes).hour < offset
+        offset_time.beginning_of_day + offset.hours - 5.minutes
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/job_id_cache.rb
+++ b/app/cache_processors/qa_server/job_id_cache.rb
@@ -19,11 +19,11 @@ module QaServer
         Rails.cache.delete(cache_key(job_key))
       end
 
-      private
+    private
 
-        def cache_key(job_key)
-          "#{job_key}-job_id"
-        end
+      def cache_key(job_key)
+        "#{job_key}-job_id"
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/performance_cache.rb
+++ b/app/cache_processors/qa_server/performance_cache.rb
@@ -49,45 +49,45 @@ module QaServer
       cache_to_write = nil # free cache for garbage collection
     end
 
-    private
+  private
 
-      def swap_cache_hash
-        cache_to_write = @cache
-        @cache = {} # reset main cache so new items after write begins are cached in the main cache
-        QaServer.config.performance_cache_logger.debug("#{self.class}##{__method__} - cache memory BEFORE write: #{ObjectSpace.memsize_of(cache_to_write)}")
-        cache_to_write
-      end
+    def swap_cache_hash
+      cache_to_write = @cache
+      @cache = {} # reset main cache so new items after write begins are cached in the main cache
+      QaServer.config.performance_cache_logger.debug("#{self.class}##{__method__} - cache memory BEFORE write: #{ObjectSpace.memsize_of(cache_to_write)}")
+      cache_to_write
+    end
 
-      def log(id:)
-        return if QaServer.config.suppress_logging_performance_datails?
-        Rails.logger.debug("*** performance data for id: #{id} ***")
-        Rails.logger.debug(@cache[id].to_yaml)
-      end
+    def log(id:)
+      return if QaServer.config.suppress_logging_performance_datails?
+      Rails.logger.debug("*** performance data for id: #{id} ***")
+      Rails.logger.debug(@cache[id].to_yaml)
+    end
 
-      def incomplete?(entry)
-        required_keys.each { |k| return true unless entry.key? k }
-        false
-      end
+    def incomplete?(entry)
+      required_keys.each { |k| return true unless entry.key? k }
+      false
+    end
 
-      def required_keys
-        [:dt_stamp,
-         :authority,
-         :action,
-         :action_time_ms,
-         :size_bytes,
-         :retrieve_time_ms,
-         :graph_load_time_ms,
-         :normalization_time_ms]
-      end
+    def required_keys
+      [:dt_stamp,
+       :authority,
+       :action,
+       :action_time_ms,
+       :size_bytes,
+       :retrieve_time_ms,
+       :graph_load_time_ms,
+       :normalization_time_ms]
+    end
 
-      def log_write_all(prefix, size_before, cache_size)
-        if size_before.positive?
-          QaServer.config.performance_cache_logger.debug("#{prefix} 0 of #{size_before} performance data records were saved") if size_before == cache_size
-          QaServer.config.performance_cache_logger.debug("#{prefix} #{size_before - cache_size} of #{size_before} performance data records were saved") if size_before > cache_size
-        else
-          QaServer.config.performance_cache_logger.debug("#{prefix} 0 of 0 performance data records were saved")
-        end
-        QaServer.config.performance_cache_logger.debug("#{prefix} - cache memory AFTER write: #{ObjectSpace.memsize_of @cache}")
+    def log_write_all(prefix, size_before, cache_size)
+      if size_before.positive?
+        QaServer.config.performance_cache_logger.debug("#{prefix} 0 of #{size_before} performance data records were saved") if size_before == cache_size
+        QaServer.config.performance_cache_logger.debug("#{prefix} #{size_before - cache_size} of #{size_before} performance data records were saved") if size_before > cache_size
+      else
+        QaServer.config.performance_cache_logger.debug("#{prefix} 0 of 0 performance data records were saved")
       end
+      QaServer.config.performance_cache_logger.debug("#{prefix} - cache memory AFTER write: #{ObjectSpace.memsize_of @cache}")
+    end
   end
 end

--- a/app/cache_processors/qa_server/performance_day_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_day_graph_cache.rb
@@ -13,15 +13,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key
-          "QaServer::PerformanceDayGraphCache.generate_graphs--latest_generation_initiated"
-        end
+      def cache_key
+        "QaServer::PerformanceDayGraphCache.generate_graphs--latest_generation_initiated"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.end_of_hour_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.end_of_hour_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/performance_month_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_month_graph_cache.rb
@@ -13,15 +13,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key
-          "QaServer::PerformanceMonthGraphCache.generate_graphs--latest_generation_initiated"
-        end
+      def cache_key
+        "QaServer::PerformanceMonthGraphCache.generate_graphs--latest_generation_initiated"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/performance_year_graph_cache.rb
+++ b/app/cache_processors/qa_server/performance_year_graph_cache.rb
@@ -13,15 +13,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key
-          "QaServer::PerformanceYearGraphCache.generate_graphs--latest_generation_initiated"
-        end
+      def cache_key
+        "QaServer::PerformanceYearGraphCache.generate_graphs--latest_generation_initiated"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/scenario_history_cache.rb
+++ b/app/cache_processors/qa_server/scenario_history_cache.rb
@@ -21,15 +21,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key_for_historical_data
-          SCENARIO_RUN_HISTORY_DATA_CACHE_KEY
-        end
+      def cache_key_for_historical_data
+        SCENARIO_RUN_HISTORY_DATA_CACHE_KEY
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/scenario_history_graph_cache.rb
+++ b/app/cache_processors/qa_server/scenario_history_graph_cache.rb
@@ -13,15 +13,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key
-          "QaServer::ScenarioHistoryGraphCache.generate_graph--latest_generation_initiated"
-        end
+      def cache_key
+        "QaServer::ScenarioHistoryGraphCache.generate_graph--latest_generation_initiated"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/scenario_run_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_cache.rb
@@ -14,15 +14,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key
-          "QaServer::ScenarioRunCache.run_tests--latest_run_initiated"
-        end
+      def cache_key
+        "QaServer::ScenarioRunCache.run_tests--latest_run_initiated"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/scenario_run_failures_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_failures_cache.rb
@@ -37,15 +37,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key_for_run_failures(id)
-          "#{SCENARIO_RUN_FAILURE_DATA_CACHE_KEY}--#{id}{"
-        end
+      def cache_key_for_run_failures(id)
+        "#{SCENARIO_RUN_FAILURE_DATA_CACHE_KEY}--#{id}{"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/cache_processors/qa_server/scenario_run_summary_cache.rb
+++ b/app/cache_processors/qa_server/scenario_run_summary_cache.rb
@@ -26,15 +26,15 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def cache_key_for_run_summary(id)
-          "#{SCENARIO_RUN_SUMMARY_DATA_CACHE_KEY}--#{id}"
-        end
+      def cache_key_for_run_summary(id)
+        "#{SCENARIO_RUN_SUMMARY_DATA_CACHE_KEY}--#{id}"
+      end
 
-        def next_expiry
-          QaServer::CacheExpiryService.cache_expiry
-        end
+      def next_expiry
+        QaServer::CacheExpiryService.cache_expiry
+      end
     end
   end
 end

--- a/app/controllers/concerns/qa_server/authority_validation_behavior.rb
+++ b/app/controllers/concerns/qa_server/authority_validation_behavior.rb
@@ -19,64 +19,64 @@ module QaServer
       self.logger_class = QaServer::ScenarioLogger
     end
 
-    private
+  private
 
-      def status_log
-        @status_log ||= logger_class.new
-      end
+    def status_log
+      @status_log ||= logger_class.new
+    end
 
-      def status_data_from_log
-        @status_data = status_log.to_a
-      end
+    def status_data_from_log
+      @status_data = status_log.to_a
+    end
 
-      def authorities_list
-        @authorities_list ||= lister_class.authorities_list
-      end
+    def authorities_list
+      @authorities_list ||= lister_class.authorities_list
+    end
 
-      def validate(authorities_list, validation_type = validator_class::DEFAULT_VALIDATION_TYPE)
-        return if authorities_list.blank?
-        result = []
-        authorities_list.each { |auth_name| result << validate_authority(auth_name, validation_type) }
-        result
-      end
+    def validate(authorities_list, validation_type = validator_class::DEFAULT_VALIDATION_TYPE)
+      return if authorities_list.blank?
+      result = []
+      authorities_list.each { |auth_name| result << validate_authority(auth_name, validation_type) }
+      result
+    end
 
-      def validate_authority(auth_name, validation_type)
-        validator_class.run(authority_name: auth_name, validation_type: validation_type, status_log: status_log)
-      end
+    def validate_authority(auth_name, validation_type)
+      validator_class.run(authority_name: auth_name, validation_type: validation_type, status_log: status_log)
+    end
 
-      def list(authorities_list)
-        return if authorities_list.blank?
-        authorities_list.each { |auth_name| list_scenarios(auth_name) }
-      end
+    def list(authorities_list)
+      return if authorities_list.blank?
+      authorities_list.each { |auth_name| list_scenarios(auth_name) }
+    end
 
-      def list_scenarios(auth_name)
-        lister_class.scenarios_list(authority_name: auth_name, status_log: status_log)
-      end
+    def list_scenarios(auth_name)
+      lister_class.scenarios_list(authority_name: auth_name, status_log: status_log)
+    end
 
-      def validating_accuracy?
-        return true if validation_type == validator_class::VALIDATE_ACCURACY
-        false
-      end
+    def validating_accuracy?
+      return true if validation_type == validator_class::VALIDATE_ACCURACY
+      false
+    end
 
-      def comparing_accuracy?
-        return true if validation_type == validator_class::VALIDATE_ACCURACY_COMPARISON
-        false
-      end
+    def comparing_accuracy?
+      return true if validation_type == validator_class::VALIDATE_ACCURACY_COMPARISON
+      false
+    end
 
-      def validation_type
-        return @validation_type if @validation_type.present?
-        case params[VALIDATION_TYPE_PARAM]
-        when ALL_VALIDATIONS
-          validator_class::ALL_VALIDATIONS
-        when VALIDATE_CONNECTIONS
-          validator_class::VALIDATE_CONNECTIONS
-        when VALIDATE_ACCURACY
-          validator_class::VALIDATE_ACCURACY
-        when VALIDATE_ACCURACY_COMPARISON
-          validator_class::VALIDATE_ACCURACY_COMPARISON
-        else
-          validator_class::DEFAULT_VALIDATION_TYPE
-        end
+    def validation_type
+      return @validation_type if @validation_type.present?
+      case params[VALIDATION_TYPE_PARAM]
+      when ALL_VALIDATIONS
+        validator_class::ALL_VALIDATIONS
+      when VALIDATE_CONNECTIONS
+        validator_class::VALIDATE_CONNECTIONS
+      when VALIDATE_ACCURACY
+        validator_class::VALIDATE_ACCURACY
+      when VALIDATE_ACCURACY_COMPARISON
+        validator_class::VALIDATE_ACCURACY_COMPARISON
+      else
+        validator_class::DEFAULT_VALIDATION_TYPE
       end
+    end
   end
 end

--- a/app/controllers/qa_server/check_status_controller.rb
+++ b/app/controllers/qa_server/check_status_controller.rb
@@ -94,7 +94,7 @@ module QaServer
       end
 
       def authorities_to_validate
-        return [] unless authority_name.present?
+        return [] if authority_name.blank?
         authority_names = authority_name == ALL_AUTHORITIES ? authorities_list : [authority_name]
         authority_names << compare_with if compare_with.present?
         authority_names

--- a/app/controllers/qa_server/check_status_controller.rb
+++ b/app/controllers/qa_server/check_status_controller.rb
@@ -22,101 +22,101 @@ module QaServer
                                        comparison_status_data: comparison_status_data_from_log)
     end
 
-    private
+  private
 
-      def connection_status_data_from_log
-        status_log.filter(type: validator_class::VALIDATE_CONNECTIONS)
-      end
+    def connection_status_data_from_log
+      status_log.filter(type: validator_class::VALIDATE_CONNECTIONS)
+    end
 
-      def accuracy_status_data_from_log
-        return [] unless validating_accuracy?
-        status_log.filter(type: validator_class::VALIDATE_ACCURACY)
-      end
+    def accuracy_status_data_from_log
+      return [] unless validating_accuracy?
+      status_log.filter(type: validator_class::VALIDATE_ACCURACY)
+    end
 
-      def comparison_status_data_from_log
-        return [] unless comparing_accuracy?
-        filtered_log = status_log.filter(type: validator_class::VALIDATE_ACCURACY, group: true)
-        return [] unless filtered_log.count == 2
-        overlay_log(filtered_log)
-      end
+    def comparison_status_data_from_log
+      return [] unless comparing_accuracy?
+      filtered_log = status_log.filter(type: validator_class::VALIDATE_ACCURACY, group: true)
+      return [] unless filtered_log.count == 2
+      overlay_log(filtered_log)
+    end
 
-      def overlay_log(log)
-        auths = log.keys
-        auth_a = log[auths[0]]
-        auth_b = log[auths[1]]
-        overlay = []
-        auth_a.each { |test| overlay << match_and_merge_test(test, auth_b) }
-        auth_b.each { |test| overlay << merge_test_results(empty_test(test), test) }
-        overlay
-      end
+    def overlay_log(log)
+      auths = log.keys
+      auth_a = log[auths[0]]
+      auth_b = log[auths[1]]
+      overlay = []
+      auth_a.each { |test| overlay << match_and_merge_test(test, auth_b) }
+      auth_b.each { |test| overlay << merge_test_results(empty_test(test), test) }
+      overlay
+    end
 
-      def match_and_merge_test(a_test, auth_b)
-        auth_b.each_with_index do |b_test, idx|
-          next unless b_test[:action] == a_test[:action]
-          next unless b_test[:subauthority_name] == a_test[:subauthority_name]
-          next unless b_test[:request_data] == a_test[:request_data]
-          next unless b_test[:target] == a_test[:target]
-          return merge_test_results(a_test, auth_b.delete_at(idx))
-        end
-        merge_test_results(a_test, empty_test(a_test))
+    def match_and_merge_test(a_test, auth_b)
+      auth_b.each_with_index do |b_test, idx|
+        next unless b_test[:action] == a_test[:action]
+        next unless b_test[:subauthority_name] == a_test[:subauthority_name]
+        next unless b_test[:request_data] == a_test[:request_data]
+        next unless b_test[:target] == a_test[:target]
+        return merge_test_results(a_test, auth_b.delete_at(idx))
       end
+      merge_test_results(a_test, empty_test(a_test))
+    end
 
-      def merge_test_results(a_test, b_test)
-        merged_tests = {}
-        merged_tests[:status] = [a_test[:status], b_test[:status]]
-        merged_tests[:service] = [a_test[:service], b_test[:service]]
-        merged_tests[:action] = a_test[:action]
-        merged_tests[:authority_name] = [a_test[:authority_name], b_test[:authority_name]]
-        merged_tests[:subauthority_name] = a_test[:subauthority_name]
-        merged_tests[:request_data] = a_test[:request_data]
-        merged_tests[:target] = a_test[:target]
-        merged_tests[:expected] = [a_test[:expected], b_test[:expected]]
-        merged_tests[:actual] = [a_test[:actual], b_test[:actual]]
-        merged_tests[:url] = [a_test[:url], b_test[:url]]
-        merged_tests[:err_message] = [a_test[:err_message], b_test[:err_message]]
-        merged_tests
-      end
+    def merge_test_results(a_test, b_test)
+      merged_tests = {}
+      merged_tests[:status] = [a_test[:status], b_test[:status]]
+      merged_tests[:service] = [a_test[:service], b_test[:service]]
+      merged_tests[:action] = a_test[:action]
+      merged_tests[:authority_name] = [a_test[:authority_name], b_test[:authority_name]]
+      merged_tests[:subauthority_name] = a_test[:subauthority_name]
+      merged_tests[:request_data] = a_test[:request_data]
+      merged_tests[:target] = a_test[:target]
+      merged_tests[:expected] = [a_test[:expected], b_test[:expected]]
+      merged_tests[:actual] = [a_test[:actual], b_test[:actual]]
+      merged_tests[:url] = [a_test[:url], b_test[:url]]
+      merged_tests[:err_message] = [a_test[:err_message], b_test[:err_message]]
+      merged_tests
+    end
 
-      def empty_test(base_test)
-        merged_tests = {}
-        merged_tests[:status] = ''
-        merged_tests[:service] = ''
-        merged_tests[:action] = base_test[:action]
-        merged_tests[:authority_name] = ''
-        merged_tests[:subauthority_name] = base_test[:subauthority_name]
-        merged_tests[:request_data] = base_test[:request_data]
-        merged_tests[:target] = base_test[:target]
-        merged_tests[:expected] = ''
-        merged_tests[:actual] = ''
-        merged_tests[:url] = ''
-        merged_tests[:err_message] = ''
-        merged_tests
-      end
+    def empty_test(base_test)
+      merged_tests = {}
+      merged_tests[:status] = ''
+      merged_tests[:service] = ''
+      merged_tests[:action] = base_test[:action]
+      merged_tests[:authority_name] = ''
+      merged_tests[:subauthority_name] = base_test[:subauthority_name]
+      merged_tests[:request_data] = base_test[:request_data]
+      merged_tests[:target] = base_test[:target]
+      merged_tests[:expected] = ''
+      merged_tests[:actual] = ''
+      merged_tests[:url] = ''
+      merged_tests[:err_message] = ''
+      merged_tests
+    end
 
-      def authorities_to_validate
-        return [] if authority_name.blank?
-        authority_names = authority_name == ALL_AUTHORITIES ? authorities_list : [authority_name]
-        authority_names << compare_with if compare_with.present?
-        authority_names
-      end
+    def authorities_to_validate
+      return [] if authority_name.blank?
+      authority_names = authority_name == ALL_AUTHORITIES ? authorities_list : [authority_name]
+      authority_names << compare_with if compare_with.present?
+      authority_names
+    end
 
-      def authority_name
-        return @authority_name if @authority_name.present?
-        @authority_name = params.key?(:authority) ? params[:authority].downcase : nil
-      end
+    def authority_name
+      return @authority_name if @authority_name.present?
+      @authority_name = params.key?(:authority) ? params[:authority].downcase : nil
+    end
 
-      def compare_with
-        return @compare_with if @compare_with.present?
-        @compare_with = params.key?(:compare_with) ? params[:compare_with].downcase : nil
-      end
+    def compare_with
+      return @compare_with if @compare_with.present?
+      @compare_with = params.key?(:compare_with) ? params[:compare_with].downcase : nil
+    end
 
-      def log_header
-        QaServer.config.performance_cache_logger.debug("----------------------  check status (max_cache_size = #{max_cache_size}) ----------------------")
-        QaServer.config.performance_cache_logger.debug("(#{self.class}##{__method__}) check status page request (authority_name # #{authority_name})")
-      end
+    def log_header
+      QaServer.config.performance_cache_logger.debug("----------------------  check status (max_cache_size = #{max_cache_size}) ----------------------")
+      QaServer.config.performance_cache_logger.debug("(#{self.class}##{__method__}) check status page request (authority_name # #{authority_name})")
+    end
 
-      def max_cache_size
-        ActiveSupport::NumberHelper.number_to_human_size(QaServer.config.max_performance_cache_size)
-      end
+    def max_cache_size
+      ActiveSupport::NumberHelper.number_to_human_size(QaServer.config.max_performance_cache_size)
+    end
   end
 end

--- a/app/controllers/qa_server/fetch_controller.rb
+++ b/app/controllers/qa_server/fetch_controller.rb
@@ -20,41 +20,41 @@ module QaServer
                                        term_results: term_results)
     end
 
-    private
+  private
 
-      def authorities_list
-        @authorities_list ||= lister_class.authorities_list
-      end
+    def authorities_list
+      @authorities_list ||= lister_class.authorities_list
+    end
 
-      # @return [Qa::Authorities::LinkedData::GenericAuthority] the instance of the QA authority
-      def authority
-        return unless authority_name?
-        @authority ||= QaServer::AuthorityLoaderService.load(authority_name: authority_name)
-      end
+    # @return [Qa::Authorities::LinkedData::GenericAuthority] the instance of the QA authority
+    def authority
+      return unless authority_name?
+      @authority ||= QaServer::AuthorityLoaderService.load(authority_name: authority_name)
+    end
 
-      def uri?
-        uri.present?
-      end
+    def uri?
+      uri.present?
+    end
 
-      def uri
-        @uri ||= params.key?(:uri) ? params[:uri] : nil
-      end
+    def uri
+      @uri ||= params.key?(:uri) ? params[:uri] : nil
+    end
 
-      def authority_name?
-        authority_name.present?
-      end
+    def authority_name?
+      authority_name.present?
+    end
 
-      def authority_name
-        @authority_name ||= params.key?(:authority) ? params[:authority].downcase : nil
-      end
+    def authority_name
+      @authority_name ||= params.key?(:authority) ? params[:authority].downcase : nil
+    end
 
-      def format
-        @format ||= params.key?(:results_format) ? params[:results_format] : 'json'
-      end
+    def format
+      @format ||= params.key?(:results_format) ? params[:results_format] : 'json'
+    end
 
-      def term_results
-        return unless authority_name? && uri?
-        @term_results = authority.find(uri, format: format)
-      end
+    def term_results
+      return unless authority_name? && uri?
+      @term_results = authority.find(uri, format: format)
+    end
   end
 end

--- a/app/controllers/qa_server/monitor_status_controller.rb
+++ b/app/controllers/qa_server/monitor_status_controller.rb
@@ -24,110 +24,110 @@ module QaServer
       render 'index', status: :internal_server_error if latest_summary.failing_authority_count.positive?
     end
 
-    private
+  private
 
-      def perform_updates
-        update_tests
-        update_historical_graph
-        update_performance_graphs
-      end
+    def perform_updates
+      update_tests
+      update_historical_graph
+      update_performance_graphs
+    end
 
-      def update_tests
-        QaServer::ScenarioRunCache.run_tests(force: refresh_tests?)
-      end
+    def update_tests
+      QaServer::ScenarioRunCache.run_tests(force: refresh_tests?)
+    end
 
-      # Sets @latest_test_run [QaServer::ScenarioRunRegistry]
-      def latest_test_run
-        @latest_test_run ||= scenario_run_registry_class.latest_run
-      end
+    # Sets @latest_test_run [QaServer::ScenarioRunRegistry]
+    def latest_test_run
+      @latest_test_run ||= scenario_run_registry_class.latest_run
+    end
 
-      # @returns [QaServer::ScenarioRunSummary] summary statistics on the latest run
-      def latest_summary
-        QaServer::ScenarioRunSummaryCache.summary_for_run(run: latest_test_run)
-      end
+    # @returns [QaServer::ScenarioRunSummary] summary statistics on the latest run
+    def latest_summary
+      QaServer::ScenarioRunSummaryCache.summary_for_run(run: latest_test_run)
+    end
 
-      # @returns [Array<Hash>] scenario details for any failing scenarios in the latest run
-      # @see QaServer::ScenarioRunHistory#run_failures for structure of output
-      def latest_failures
-        QaServer::ScenarioRunFailuresCache.failures_for_run(run: latest_test_run)
-      end
+    # @returns [Array<Hash>] scenario details for any failing scenarios in the latest run
+    # @see QaServer::ScenarioRunHistory#run_failures for structure of output
+    def latest_failures
+      QaServer::ScenarioRunFailuresCache.failures_for_run(run: latest_test_run)
+    end
 
-      # Get a summary level of historical data
-      # @returns [Array<Hash>] summary of passing/failing tests for each authority
-      # @see QaServer::ScenarioRunHistory#historical_summary for structure of output
-      def historical_data
-        @historical_data ||= QaServer::ScenarioHistoryCache.historical_summary(force: refresh_history?)
-      end
+    # Get a summary level of historical data
+    # @returns [Array<Hash>] summary of passing/failing tests for each authority
+    # @see QaServer::ScenarioRunHistory#historical_summary for structure of output
+    def historical_data
+      @historical_data ||= QaServer::ScenarioHistoryCache.historical_summary(force: refresh_history?)
+    end
 
-      def update_historical_graph
-        return unless QaServer.config.display_historical_graph?
-        QaServer::ScenarioHistoryGraphCache.generate_graph(data: historical_data, force: refresh_history?)
-      end
+    def update_historical_graph
+      return unless QaServer.config.display_historical_graph?
+      QaServer::ScenarioHistoryGraphCache.generate_graph(data: historical_data, force: refresh_history?)
+    end
 
-      def performance_table_data
-        return {} unless QaServer.config.display_performance_datatable?
-        QaServer::PerformanceDatatableCache.data(force: refresh_performance_table?)
-      end
+    def performance_table_data
+      return {} unless QaServer.config.display_performance_datatable?
+      QaServer::PerformanceDatatableCache.data(force: refresh_performance_table?)
+    end
 
-      def update_performance_graphs
-        return unless QaServer.config.display_performance_graph?
-        QaServer::PerformanceDayGraphCache.generate_graphs(force: refresh_performance_graphs?)
-        QaServer::PerformanceMonthGraphCache.generate_graphs(force: refresh_performance_graphs?)
-        QaServer::PerformanceYearGraphCache.generate_graphs(force: refresh_performance_graphs?)
-      end
+    def update_performance_graphs
+      return unless QaServer.config.display_performance_graph?
+      QaServer::PerformanceDayGraphCache.generate_graphs(force: refresh_performance_graphs?)
+      QaServer::PerformanceMonthGraphCache.generate_graphs(force: refresh_performance_graphs?)
+      QaServer::PerformanceYearGraphCache.generate_graphs(force: refresh_performance_graphs?)
+    end
 
-      def refresh?
-        params.key?(:refresh) && validate_auth_reload_token("refresh status")
-      end
+    def refresh?
+      params.key?(:refresh) && validate_auth_reload_token("refresh status")
+    end
 
-      def refresh_all?
-        return false unless refresh?
-        params[:refresh].nil? || params[:refresh].casecmp?('all') # nil is for backward compatibility
-      end
+    def refresh_all?
+      return false unless refresh?
+      params[:refresh].nil? || params[:refresh].casecmp?('all') # nil is for backward compatibility
+    end
 
-      def refresh_tests?
-        refresh? ? (refresh_all? || params[:refresh].casecmp?('tests')) : false
-      end
+    def refresh_tests?
+      refresh? ? (refresh_all? || params[:refresh].casecmp?('tests')) : false
+    end
 
-      def refresh_history?
-        refresh? ? (refresh_all? || params[:refresh].casecmp?('history')) : false
-      end
+    def refresh_history?
+      refresh? ? (refresh_all? || params[:refresh].casecmp?('history')) : false
+    end
 
-      def refresh_performance?
-        refresh? ? (refresh_all? || params[:refresh].casecmp?('performance')) : false
-      end
+    def refresh_performance?
+      refresh? ? (refresh_all? || params[:refresh].casecmp?('performance')) : false
+    end
 
-      def refresh_performance_table?
-        refresh? ? (refresh_performance? || params[:refresh].casecmp?('performance_table')) : false
-      end
+    def refresh_performance_table?
+      refresh? ? (refresh_performance? || params[:refresh].casecmp?('performance_table')) : false
+    end
 
-      def refresh_performance_graphs?
-        refresh? ? (refresh_performance? || params[:refresh].casecmp?('performance_graphs')) : false
-      end
+    def refresh_performance_graphs?
+      refresh? ? (refresh_performance? || params[:refresh].casecmp?('performance_graphs')) : false
+    end
 
-      def commit_cache?
-        params.key?(:commit) && validate_auth_reload_token("commit cache")
-      end
+    def commit_cache?
+      params.key?(:commit) && validate_auth_reload_token("commit cache")
+    end
 
-      def commit_cache
-        QaServer.config.performance_cache.write_all
-      end
+    def commit_cache
+      QaServer.config.performance_cache.write_all
+    end
 
-      def validate_auth_reload_token(action)
-        token = params.key?(:auth_token) ? params[:auth_token] : nil
-        valid = Qa.config.valid_authority_reload_token?(token)
-        return true if valid
-        msg = "Permission denied. Unable to #{action}."
-        logger.warn msg
-        flash.now[:error] = msg
-        false
-      end
+    def validate_auth_reload_token(action)
+      token = params.key?(:auth_token) ? params[:auth_token] : nil
+      valid = Qa.config.valid_authority_reload_token?(token)
+      return true if valid
+      msg = "Permission denied. Unable to #{action}."
+      logger.warn msg
+      flash.now[:error] = msg
+      false
+    end
 
-      def log_header
-        QaServer.config.monitor_logger.debug("------------------------------------  monitor status  -----------------------------------")
-        QaServer.config.monitor_logger.debug("refresh_all? #{refresh_all?}, refresh_tests? #{refresh_tests?}, refresh_history? #{refresh_history?}")
-        QaServer.config.monitor_logger.debug("refresh_performance? #{refresh_performance?}, refresh_performance_table? #{refresh_performance_table?}, " \
-                                             "refresh_performance_graphs? #{refresh_performance_graphs?})")
-      end
+    def log_header
+      QaServer.config.monitor_logger.debug("------------------------------------  monitor status  -----------------------------------")
+      QaServer.config.monitor_logger.debug("refresh_all? #{refresh_all?}, refresh_tests? #{refresh_tests?}, refresh_history? #{refresh_history?}")
+      QaServer.config.monitor_logger.debug("refresh_performance? #{refresh_performance?}, refresh_performance_table? #{refresh_performance_table?}, " \
+                                           "refresh_performance_graphs? #{refresh_performance_graphs?})")
+    end
   end
 end

--- a/app/jobs/qa_server/history_graph_job.rb
+++ b/app/jobs/qa_server/history_graph_job.rb
@@ -12,17 +12,17 @@ module QaServer
       generate_graph(data) if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
     end
 
-    private
+  private
 
-      def generate_graph(data)
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) - GENERATING historical summary graph")
-        graphing_service.generate_graph(data)
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED historical summary graph generation")
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-      end
+    def generate_graph(data)
+      QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) - GENERATING historical summary graph")
+      graphing_service.generate_graph(data)
+      QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED historical summary graph generation")
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+    end
 
-      def job_key
-        "QaServer::HistoryGraphJob--job_id"
-      end
+    def job_key
+      "QaServer::HistoryGraphJob--job_id"
+    end
   end
 end

--- a/app/jobs/qa_server/monitor_tests_job.rb
+++ b/app/jobs/qa_server/monitor_tests_job.rb
@@ -14,25 +14,25 @@ module QaServer
       run_tests if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id, expires_in: 2.hours)
     end
 
-    private
+  private
 
-      def run_tests
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) RUNNING monitoring tests")
-        validate(authorities_list)
-        log_results(authorities_list, status_log.to_a)
-        scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
-        QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
-        QaServer.config.performance_cache.write_all # write out cache after completing tests
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-      end
+    def run_tests
+      QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) RUNNING monitoring tests")
+      validate(authorities_list)
+      log_results(authorities_list, status_log.to_a)
+      scenario_run_registry_class.save_run(scenarios_results: status_log.to_a)
+      QaServer.config.monitor_logger.debug("(#{self.class}##{__method__}-#{job_id}) COMPLETED monitoring tests")
+      QaServer.config.performance_cache.write_all # write out cache after completing tests
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+    end
 
-      def log_results(authorities_list, results)
-        QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) authorities_list is empty") if authorities_list&.empty?
-        QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) test results are empty") if results&.empty?
-      end
+    def log_results(authorities_list, results)
+      QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) authorities_list is empty") if authorities_list&.empty?
+      QaServer.config.monitor_logger.warn("(#{self.class}##{__method__}-#{job_id}) test results are empty") if results&.empty?
+    end
 
-      def job_key
-        "QaServer::MonitorTestsJob--job_id"
-      end
+    def job_key
+      "QaServer::MonitorTestsJob--job_id"
+    end
   end
 end

--- a/app/jobs/qa_server/performance_day_graph_job.rb
+++ b/app/jobs/qa_server/performance_day_graph_job.rb
@@ -16,30 +16,30 @@ module QaServer
       generate_graphs_for_authorities if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
     end
 
-    private
+  private
 
-      def generate_graphs_for_authorities
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance day graph")
-        auths = authority_list_class.authorities_list
-        generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
-        auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance day graph generation")
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-      end
+    def generate_graphs_for_authorities
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance day graph")
+      auths = authority_list_class.authorities_list
+      generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+      auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance day graph generation")
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+    end
 
-      def generate_graphs_for_authority(authority_name:)
-        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-          hash[action] = generate_24_hour_graph(authority_name: authority_name, action: action)
-        end
+    def generate_graphs_for_authority(authority_name:)
+      [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+        hash[action] = generate_24_hour_graph(authority_name: authority_name, action: action)
       end
+    end
 
-      def generate_24_hour_graph(authority_name:, action:)
-        data = graph_data_service.calculate_last_24_hours(authority_name: authority_name, action: action)
-        graphing_service.generate_day_graph(authority_name: authority_name, action: action, data: data)
-      end
+    def generate_24_hour_graph(authority_name:, action:)
+      data = graph_data_service.calculate_last_24_hours(authority_name: authority_name, action: action)
+      graphing_service.generate_day_graph(authority_name: authority_name, action: action, data: data)
+    end
 
-      def job_key
-        "QaServer::PerformanceDayGraphJob--job_id"
-      end
+    def job_key
+      "QaServer::PerformanceDayGraphJob--job_id"
+    end
   end
 end

--- a/app/jobs/qa_server/performance_month_graph_job.rb
+++ b/app/jobs/qa_server/performance_month_graph_job.rb
@@ -16,30 +16,30 @@ module QaServer
       generate_graphs_for_authorities if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
     end
 
-    private
+  private
 
-      def generate_graphs_for_authorities
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance month graph")
-        auths = authority_list_class.authorities_list
-        generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
-        auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance month graph generation")
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-      end
+    def generate_graphs_for_authorities
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance month graph")
+      auths = authority_list_class.authorities_list
+      generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+      auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance month graph generation")
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+    end
 
-      def generate_graphs_for_authority(authority_name:)
-        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-          hash[action] = generate_30_day_graph(authority_name: authority_name, action: action)
-        end
+    def generate_graphs_for_authority(authority_name:)
+      [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+        hash[action] = generate_30_day_graph(authority_name: authority_name, action: action)
       end
+    end
 
-      def generate_30_day_graph(authority_name:, action:)
-        data = graph_data_service.calculate_last_30_days(authority_name: authority_name, action: action)
-        graphing_service.generate_month_graph(authority_name: authority_name, action: action, data: data)
-      end
+    def generate_30_day_graph(authority_name:, action:)
+      data = graph_data_service.calculate_last_30_days(authority_name: authority_name, action: action)
+      graphing_service.generate_month_graph(authority_name: authority_name, action: action, data: data)
+    end
 
-      def job_key
-        "QaServer::PerformanceMonthGraphJob--job_id"
-      end
+    def job_key
+      "QaServer::PerformanceMonthGraphJob--job_id"
+    end
   end
 end

--- a/app/jobs/qa_server/performance_per_byte_job.rb
+++ b/app/jobs/qa_server/performance_per_byte_job.rb
@@ -16,70 +16,70 @@ module QaServer
       generate_data_for_authorities(n, action, authority_complexity_ratings) if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
     end
 
-    private
+  private
 
-      def generate_data_for_authorities(n, action, authority_complexity_ratings)
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance by byte data")
-        auths = authority_list_class.authorities_list
-        data = if action.nil?
-                 # generate_data_for_authority(ALL_AUTH, n) # generates data for all authorities
-                 auths.each_with_object({}) { |authname, hash| hash[authname] = generate_data_for_authority(authname, n) }
-               else
-                 auths.each_with_object({}) { |authname, hash| hash[authname] = { action => generate_data(authname, action, n) } }
-               end
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance by byte data generation")
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-        convert_to_csv(data, authority_complexity_ratings)
+    def generate_data_for_authorities(n, action, authority_complexity_ratings)
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance by byte data")
+      auths = authority_list_class.authorities_list
+      data = if action.nil?
+               # generate_data_for_authority(ALL_AUTH, n) # generates data for all authorities
+               auths.each_with_object({}) { |authname, hash| hash[authname] = generate_data_for_authority(authname, n) }
+             else
+               auths.each_with_object({}) { |authname, hash| hash[authname] = { action => generate_data(authname, action, n) } }
+             end
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance by byte data generation")
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+      convert_to_csv(data, authority_complexity_ratings)
+    end
+
+    def generate_data_for_authority(authority_name, n)
+      [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+        hash[action] = generate_data(authority_name, action, n)
       end
+    end
 
-      def generate_data_for_authority(authority_name, n)
-        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-          hash[action] = generate_data(authority_name, action, n)
-        end
-      end
+    def generate_data(authority_name, action, n)
+      data_service.calculate(authority_name: authority_name, action: action, n: n)
+      # graphing_service.generate_day_graph(authority_name: authority_name, action: action, data: data)
+    end
 
-      def generate_data(authority_name, action, n)
-        data_service.calculate(authority_name: authority_name, action: action, n: n)
-        # graphing_service.generate_day_graph(authority_name: authority_name, action: action, data: data)
-      end
-
-      # @param data [Hash] performance statistics based on size of data
-      # @param authority_complexity_ratings [Hash] complexity rating of the extended context included with results
-      # @example data
-      #   { data_raw_bytes_from_source: [16271, 16271],
-      #     retrieve_bytes_per_ms: [67.24433786890475, 55.51210410757532],
-      #     retrieve_ms_per_byte: [0.014871140555351083, 0.018014089288745542]
-      #     graph_load_bytes_per_ms_ms: [86.74089418722461, 54.97464153778724],
-      #     graph_load_ms_per_byte: [0.011528587632974647, 0.018190205011389522],
-      #     normalization_bytes_per_ms: [64.70169466560836, 89.25337465693322],
-      #     normalization_ms_per_byte: [0.01530700843338457, 0.015455545718983178]
-      #   }
-      def convert_to_csv(data, authority_complexity_ratings) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-        performance_file = File.new('log/performance.csv', 'w')
-        performance_file.write("authority name, complexity_rating, action, size_bytes, ")
-        performance_file.write("retrieve_bytes_per_ms, graph_load_bytes_per_ms, normalize_bytes_per_ms, ")
-        performance_file.puts("retrieve_ms_per_byte, graph_load_ms_per_byte, normalize_ms_per_byte")
-        data.each do |auth_name, auth_data|
-          complexity_rating = authority_complexity_ratings.key?(auth_name) ? authority_complexity_ratings[auth_name] : "UNKNOWN"
-          auth_data.each do |action, action_data|
-            auth_action = "#{auth_name}, #{complexity_rating}, #{action}"
-            0.upto(action_data[:retrieve_bytes_per_ms].size - 1) do |idx|
-              performance_file.write(auth_action)
-              performance_file.write(", #{action_data[SRC_BYTES][idx]}")
-              performance_file.write(", #{action_data[BPMS_RETR][idx]}")
-              performance_file.write(", #{action_data[BPMS_GRPH][idx]}")
-              performance_file.write(", #{action_data[BPMS_NORM][idx]}")
-              performance_file.write(", #{action_data[MSPB_RETR][idx]}")
-              performance_file.write(", #{action_data[MSPB_GRPH][idx]}")
-              performance_file.puts(", #{action_data[MSPB_NORM][idx]}")
-            end
+    # @param data [Hash] performance statistics based on size of data
+    # @param authority_complexity_ratings [Hash] complexity rating of the extended context included with results
+    # @example data
+    #   { data_raw_bytes_from_source: [16271, 16271],
+    #     retrieve_bytes_per_ms: [67.24433786890475, 55.51210410757532],
+    #     retrieve_ms_per_byte: [0.014871140555351083, 0.018014089288745542]
+    #     graph_load_bytes_per_ms_ms: [86.74089418722461, 54.97464153778724],
+    #     graph_load_ms_per_byte: [0.011528587632974647, 0.018190205011389522],
+    #     normalization_bytes_per_ms: [64.70169466560836, 89.25337465693322],
+    #     normalization_ms_per_byte: [0.01530700843338457, 0.015455545718983178]
+    #   }
+    def convert_to_csv(data, authority_complexity_ratings) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      performance_file = File.new('log/performance.csv', 'w')
+      performance_file.write("authority name, complexity_rating, action, size_bytes, ")
+      performance_file.write("retrieve_bytes_per_ms, graph_load_bytes_per_ms, normalize_bytes_per_ms, ")
+      performance_file.puts("retrieve_ms_per_byte, graph_load_ms_per_byte, normalize_ms_per_byte")
+      data.each do |auth_name, auth_data|
+        complexity_rating = authority_complexity_ratings.key?(auth_name) ? authority_complexity_ratings[auth_name] : "UNKNOWN"
+        auth_data.each do |action, action_data|
+          auth_action = "#{auth_name}, #{complexity_rating}, #{action}"
+          0.upto(action_data[:retrieve_bytes_per_ms].size - 1) do |idx|
+            performance_file.write(auth_action)
+            performance_file.write(", #{action_data[SRC_BYTES][idx]}")
+            performance_file.write(", #{action_data[BPMS_RETR][idx]}")
+            performance_file.write(", #{action_data[BPMS_GRPH][idx]}")
+            performance_file.write(", #{action_data[BPMS_NORM][idx]}")
+            performance_file.write(", #{action_data[MSPB_RETR][idx]}")
+            performance_file.write(", #{action_data[MSPB_GRPH][idx]}")
+            performance_file.puts(", #{action_data[MSPB_NORM][idx]}")
           end
         end
-        performance_file.close
       end
+      performance_file.close
+    end
 
-      def job_key
-        "QaServer::PerformanceByByteJob--job_id"
-      end
+    def job_key
+      "QaServer::PerformanceByByteJob--job_id"
+    end
   end
 end

--- a/app/jobs/qa_server/performance_year_graph_job.rb
+++ b/app/jobs/qa_server/performance_year_graph_job.rb
@@ -16,30 +16,30 @@ module QaServer
       generate_graphs_for_authorities if QaServer::JobIdCache.active_job_id?(job_key: job_key, job_id: job_id)
     end
 
-    private
+  private
 
-      def generate_graphs_for_authorities
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance year graph")
-        auths = authority_list_class.authorities_list
-        generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
-        auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
-        QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance year graph generation")
-        QaServer::JobIdCache.reset_job_id(job_key: job_key)
-      end
+    def generate_graphs_for_authorities
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) - GENERATING performance year graph")
+      auths = authority_list_class.authorities_list
+      generate_graphs_for_authority(authority_name: ALL_AUTH) # generates graph for all authorities
+      auths.each { |authname| generate_graphs_for_authority(authority_name: authname) }
+      QaServer.config.monitor_logger.debug("(#{self.class}-#{job_id}) COMPLETED performance year graph generation")
+      QaServer::JobIdCache.reset_job_id(job_key: job_key)
+    end
 
-      def generate_graphs_for_authority(authority_name:)
-        [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
-          hash[action] = generate_12_month_graph(authority_name: authority_name, action: action)
-        end
+    def generate_graphs_for_authority(authority_name:)
+      [SEARCH, FETCH, ALL_ACTIONS].each_with_object({}) do |action, hash|
+        hash[action] = generate_12_month_graph(authority_name: authority_name, action: action)
       end
+    end
 
-      def generate_12_month_graph(authority_name:, action:)
-        data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
-        graphing_service.generate_year_graph(authority_name: authority_name, action: action, data: data)
-      end
+    def generate_12_month_graph(authority_name:, action:)
+      data = graph_data_service.calculate_last_12_months(authority_name: authority_name, action: action)
+      graphing_service.generate_year_graph(authority_name: authority_name, action: action, data: data)
+    end
 
-      def job_key
-        "QaServer::PerformanceYearGraphJob--job_id"
-      end
+    def job_key
+      "QaServer::PerformanceYearGraphJob--job_id"
+    end
   end
 end

--- a/app/loggers/qa_server/scenario_logger.rb
+++ b/app/loggers/qa_server/scenario_logger.rb
@@ -63,7 +63,7 @@ module QaServer
     # Append a log to this log.
     # @param [ScenarioLog] the log to append to this log
     def append(other)
-      return unless other.present?
+      return if other.blank?
       @log += other.to_a
       @test_count += other.test_count
       @failure_count += other.failure_count

--- a/app/models/qa_server/authority_status.rb
+++ b/app/models/qa_server/authority_status.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 # Provide access to the authority_status database table which tracks a summary of status data over time.
 module QaServer
-  class AuthorityStatus < ActiveRecord::Base
+  class AuthorityStatus < ApplicationRecord
     self.table_name = 'authority_status'
-    has_many :authority_status_failure, foreign_key: :authority_status_id
+    has_many :authority_status_failure, dependent: :destroy
 
     # Get the latest saved status.
     def self.latest

--- a/app/models/qa_server/authority_status_failure.rb
+++ b/app/models/qa_server/authority_status_failure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Provide access to the authority_status_failure database table which tracks specific failures over time.
 module QaServer
-  class AuthorityStatusFailure < ActiveRecord::Base
+  class AuthorityStatusFailure < ApplicationRecord
     self.table_name = 'authority_status_failure'
     belongs_to :authority_status
   end

--- a/app/models/qa_server/performance_history.rb
+++ b/app/models/qa_server/performance_history.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # Provide access to the scenario_results_history database table which tracks specific scenario runs over time.
 module QaServer
-  class PerformanceHistory < ActiveRecord::Base
+  class PerformanceHistory < ApplicationRecord
     self.table_name = 'performance_history'
 
-    enum action: [:fetch, :search]
+    enum action: { fetch: 0, search: 1 }
 
     class_attribute :datatable_data_service_class, :graph_data_service_class
     self.datatable_data_service_class = QaServer::PerformanceDatatableService

--- a/app/models/qa_server/scenario_run_history.rb
+++ b/app/models/qa_server/scenario_run_history.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Provide access to the scenario_run_history database table which tracks scenario runs over time.
 module QaServer
-  class ScenarioRunHistory < ActiveRecord::Base
+  class ScenarioRunHistory < ApplicationRecord
     self.table_name = 'scenario_run_history'
     belongs_to :scenario_run_registry
-    enum scenario_type: [:connection, :accuracy, :performance], _suffix: :type
-    enum status: [:good, :bad, :unknown], _suffix: true
+    enum scenario_type: { connection: 0, accuracy: 1, performance: 2 }, _suffix: :type
+    enum status: { good: 0, bad: 1, unknown: 2 }, _suffix: true
 
     GOOD_MARKER = '√'
     BAD_MARKER = 'X'

--- a/app/models/qa_server/scenario_run_registry.rb
+++ b/app/models/qa_server/scenario_run_registry.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 # Provide access to the scenario_run_registry database table which registers each run of tests made over time.
 module QaServer
-  class ScenarioRunRegistry < ActiveRecord::Base
+  class ScenarioRunRegistry < ApplicationRecord
     self.table_name = 'scenario_run_registry'
-    has_many :scenario_run_history, foreign_key: :scenario_run_registry_id
+    has_many :scenario_run_history, dependent: :destroy
 
     # @return [ScenarioRunRegistry] registry data for latest run (e.g. id, dt_stamp)
     def self.latest_run

--- a/app/models/qa_server/scenarios.rb
+++ b/app/models/qa_server/scenarios.rb
@@ -32,38 +32,38 @@ module QaServer
       parse_search_scenarios
     end
 
-    private
+  private
 
-      def parse_term_scenarios
-        @term_scenarios = []
-        term_scenarios_config.each do |term_scenario_config|
-          @term_scenarios << QaServer::TermScenario.new(authority: authority,
-                                                        authority_name: authority_name,
-                                                        authority_scenario_config: authority_scenario_config,
-                                                        scenario_config: term_scenario_config)
-        end
+    def parse_term_scenarios
+      @term_scenarios = []
+      term_scenarios_config.each do |term_scenario_config|
+        @term_scenarios << QaServer::TermScenario.new(authority: authority,
+                                                      authority_name: authority_name,
+                                                      authority_scenario_config: authority_scenario_config,
+                                                      scenario_config: term_scenario_config)
       end
+    end
 
-      def parse_search_scenarios
-        @search_scenarios = []
-        search_scenarios_config.each do |search_scenario_config|
-          @search_scenarios << QaServer::SearchScenario.new(authority: authority,
-                                                            authority_name: authority_name,
-                                                            authority_scenario_config: authority_scenario_config,
-                                                            scenario_config: search_scenario_config)
-        end
+    def parse_search_scenarios
+      @search_scenarios = []
+      search_scenarios_config.each do |search_scenario_config|
+        @search_scenarios << QaServer::SearchScenario.new(authority: authority,
+                                                          authority_name: authority_name,
+                                                          authority_scenario_config: authority_scenario_config,
+                                                          scenario_config: search_scenario_config)
       end
+    end
 
-      def authority_scenario_config
-        scenarios_config[AUTHORITY_SCENARIO]
-      end
+    def authority_scenario_config
+      scenarios_config[AUTHORITY_SCENARIO]
+    end
 
-      def term_scenarios_config
-        scenarios_config[TERM_SCENARIOS] || []
-      end
+    def term_scenarios_config
+      scenarios_config[TERM_SCENARIOS] || []
+    end
 
-      def search_scenarios_config
-        scenarios_config[SEARCH_SCENARIOS] || []
-      end
+    def search_scenarios_config
+      scenarios_config[SEARCH_SCENARIOS] || []
+    end
   end
 end

--- a/app/models/qa_server/search_scenario.rb
+++ b/app/models/qa_server/search_scenario.rb
@@ -47,18 +47,18 @@ module QaServer
       @pending
     end
 
-    private
+  private
 
-      # Convert replacements hash into URL parameters
-      def url_replacements
-        return "&maxRecords=#{MAX_RECORDS}" unless replacements
-        param_replacements = ""
-        replacements.each { |k, v| param_replacements += "&#{k}=#{v}" }
-        param_replacements
-      end
+    # Convert replacements hash into URL parameters
+    def url_replacements
+      return "&maxRecords=#{MAX_RECORDS}" unless replacements
+      param_replacements = ""
+      replacements.each { |k, v| param_replacements += "&#{k}=#{v}" }
+      param_replacements
+    end
 
-      def subauthority?
-        subauthority_name.present?
-      end
+    def subauthority?
+      subauthority_name.present?
+    end
   end
 end

--- a/app/models/qa_server/term_scenario.rb
+++ b/app/models/qa_server/term_scenario.rb
@@ -26,41 +26,41 @@ module QaServer
       authority.term_id_expects_uri? ? fetch_url : show_url
     end
 
-    private
+  private
 
-      # Generate an example URL that can be called in a browser or through curl
-      # @return [String] the example URL
-      def show_url
-        "#{prefix_for_url('show')}/#{url_identifier}"
-      end
+    # Generate an example URL that can be called in a browser or through curl
+    # @return [String] the example URL
+    def show_url
+      "#{prefix_for_url('show')}/#{url_identifier}"
+    end
 
-      # Generate an example URL that can be called in a browser or through curl
-      # @return [String] the example URL
-      def fetch_url
-        "#{prefix_for_url('fetch')}?uri=#{url_identifier}"
-      end
+    # Generate an example URL that can be called in a browser or through curl
+    # @return [String] the example URL
+    def fetch_url
+      "#{prefix_for_url('fetch')}?uri=#{url_identifier}"
+    end
 
-      def prefix_for_url(action)
-        subauth = "/#{subauthority_name}" if subauthority_name.present?
-        "#{QaServer::Engine.qa_engine_mount}/#{action}/linked_data/#{authority_name.downcase}#{subauth}"
-      end
+    def prefix_for_url(action)
+      subauth = "/#{subauthority_name}" if subauthority_name.present?
+      "#{QaServer::Engine.qa_engine_mount}/#{action}/linked_data/#{authority_name.downcase}#{subauth}"
+    end
 
-      # Convert identifier into URL safe version with encoding if needed.
-      def url_identifier
-        return uri_encode(identifier) if encode?
-        identifier
-      end
+    # Convert identifier into URL safe version with encoding if needed.
+    def url_identifier
+      return uri_encode(identifier) if encode?
+      identifier
+    end
 
-      def subauthority?
-        subauthority_name.present?
-      end
+    def subauthority?
+      subauthority_name.present?
+    end
 
-      def encode?
-        authority.term_id_expects_uri?
-      end
+    def encode?
+      authority.term_id_expects_uri?
+    end
 
-      def uri_encode(uri)
-        url_encode(uri).gsub(".", "%2E")
-      end
+    def uri_encode(uri)
+      url_encode(uri).gsub(".", "%2E")
+    end
   end
 end

--- a/app/prepends/prepended_linked_data/find_term.rb
+++ b/app/prepends/prepended_linked_data/find_term.rb
@@ -17,52 +17,52 @@ module PrependedLinkedData::FindTerm
     requested_results(full_results)
   end
 
-  private
+private
 
-    def setup_find(request_header: {}, language: nil, replacements: {}, subauth: nil, format: nil, performance_data: false) # rubocop:disable Metrics/ParameterLists
-      QaServer.log_agent_info(request_header[:request])
-      @start_time_s = QaServer::TimeService.current_time_s
-      request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, format: format, performance_data: performance_data) if request_header.empty?
-      @saved_performance_data = performance_data || request_header[:performance_data]
-      request_header[:performance_data] = true
-      request_header
-    end
+  def setup_find(request_header: {}, language: nil, replacements: {}, subauth: nil, format: nil, performance_data: false) # rubocop:disable Metrics/ParameterLists
+    QaServer.log_agent_info(request_header[:request])
+    @start_time_s = QaServer::TimeService.current_time_s
+    request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, format: format, performance_data: performance_data) if request_header.empty?
+    @saved_performance_data = performance_data || request_header[:performance_data]
+    request_header[:performance_data] = true
+    request_header
+  end
 
-    def update_performance_history_record(full_results)
-      return QaServer.config.performance_cache.destroy(@phid) unless full_results.is_a?(Hash) && full_results.key?(:performance)
-      updates = { action_time_ms: (QaServer::TimeService.current_time_s - @start_time_s) * 1000,
-                  size_bytes: full_results[:performance][:fetched_bytes],
-                  retrieve_plus_graph_load_time_ms: full_results[:performance][:fetch_time_s] * 1000,
-                  normalization_time_ms: full_results[:performance][:normalization_time_s] * 1000 }
-      QaServer.config.performance_cache.update(id: @phid, updates: updates)
-      QaServer.config.performance_cache.complete_entry(id: @phid)
-    end
+  def update_performance_history_record(full_results)
+    return QaServer.config.performance_cache.destroy(@phid) unless full_results.is_a?(Hash) && full_results.key?(:performance)
+    updates = { action_time_ms: (QaServer::TimeService.current_time_s - @start_time_s) * 1000,
+                size_bytes: full_results[:performance][:fetched_bytes],
+                retrieve_plus_graph_load_time_ms: full_results[:performance][:fetch_time_s] * 1000,
+                normalization_time_ms: full_results[:performance][:normalization_time_s] * 1000 }
+    QaServer.config.performance_cache.update(id: @phid, updates: updates)
+    QaServer.config.performance_cache.complete_entry(id: @phid)
+  end
 
-    # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
-    def load_graph(url:)
-      return super if QaServer.config.suppress_performance_gathering?
+  # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
+  def load_graph(url:)
+    return super if QaServer.config.suppress_performance_gathering?
 
-      access_start_dt = QaServer::TimeService.current_time
+    access_start_dt = QaServer::TimeService.current_time
 
-      url += "&phid=#{@phid}"
-      @full_graph = graph_service.load_graph(url: url)
+    url += "&phid=#{@phid}"
+    @full_graph = graph_service.load_graph(url: url)
 
-      access_end_dt = QaServer::TimeService.current_time
-      @access_time_s = access_end_dt - access_start_dt
-      @fetched_size = full_graph.triples.to_s.size if performance_data?
-      Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
-    end
+    access_end_dt = QaServer::TimeService.current_time
+    @access_time_s = access_end_dt - access_start_dt
+    @fetched_size = full_graph.triples.to_s.size if performance_data?
+    Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
+  end
 
-    # Temporary override to fix bug.  Remove when QA Issue #271 is fixed and a new release is cut
-    def performance_data?
-      return super if QaServer.config.suppress_performance_gathering?
-      @performance_data == true
-    end
+  # Temporary override to fix bug.  Remove when QA Issue #271 is fixed and a new release is cut
+  def performance_data?
+    return super if QaServer.config.suppress_performance_gathering?
+    @performance_data == true
+  end
 
-    def requested_results(full_results)
-      return full_results if @saved_performance_data || !full_results.is_a?(Hash)
-      return full_results[:results] unless full_results.key? :response_header
-      full_results.delete(:performance)
-      full_results
-    end
+  def requested_results(full_results)
+    return full_results if @saved_performance_data || !full_results.is_a?(Hash)
+    return full_results[:results] unless full_results.key? :response_header
+    full_results.delete(:performance)
+    full_results
+  end
 end

--- a/app/prepends/prepended_linked_data/search_query.rb
+++ b/app/prepends/prepended_linked_data/search_query.rb
@@ -17,46 +17,46 @@ module PrependedLinkedData::SearchQuery
     requested_results(full_results)
   end
 
-  private
+private
 
-    def setup_search(request_header: {}, language: nil, replacements: {}, subauth: nil, context: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
-      QaServer.log_agent_info(request_header[:request])
-      @start_time_s = QaServer::TimeService.current_time_s
-      request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, context: context, performance_data: performance_data) if request_header.empty?
-      @saved_performance_data = performance_data || request_header[:performance_data]
-      request_header[:performance_data] = true
-      request_header
-    end
+  def setup_search(request_header: {}, language: nil, replacements: {}, subauth: nil, context: false, performance_data: false) # rubocop:disable Metrics/ParameterLists
+    QaServer.log_agent_info(request_header[:request])
+    @start_time_s = QaServer::TimeService.current_time_s
+    request_header = build_request_header(language: language, replacements: replacements, subauth: subauth, context: context, performance_data: performance_data) if request_header.empty?
+    @saved_performance_data = performance_data || request_header[:performance_data]
+    request_header[:performance_data] = true
+    request_header
+  end
 
-    def update_performance_history_record(full_results)
-      return QaServer.config.performance_cache.destroy(@phid) unless full_results.is_a?(Hash) && full_results.key?(:performance)
-      updates = { action_time_ms: (QaServer::TimeService.current_time_s - @start_time_s) * 1000,
-                  size_bytes: full_results[:performance][:fetched_bytes],
-                  retrieve_plus_graph_load_time_ms: full_results[:performance][:fetch_time_s] * 1000,
-                  normalization_time_ms: full_results[:performance][:normalization_time_s] * 1000 }
-      QaServer.config.performance_cache.update(id: @phid, updates: updates)
-      QaServer.config.performance_cache.complete_entry(id: @phid)
-    end
+  def update_performance_history_record(full_results)
+    return QaServer.config.performance_cache.destroy(@phid) unless full_results.is_a?(Hash) && full_results.key?(:performance)
+    updates = { action_time_ms: (QaServer::TimeService.current_time_s - @start_time_s) * 1000,
+                size_bytes: full_results[:performance][:fetched_bytes],
+                retrieve_plus_graph_load_time_ms: full_results[:performance][:fetch_time_s] * 1000,
+                normalization_time_ms: full_results[:performance][:normalization_time_s] * 1000 }
+    QaServer.config.performance_cache.update(id: @phid, updates: updates)
+    QaServer.config.performance_cache.complete_entry(id: @phid)
+  end
 
-    # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
-    def load_graph(url:)
-      return super if QaServer.config.suppress_performance_gathering?
+  # Override to append performance history record id into the URL to allow access to the record in RDF::Graph
+  def load_graph(url:)
+    return super if QaServer.config.suppress_performance_gathering?
 
-      access_start_dt = QaServer::TimeService.current_time
+    access_start_dt = QaServer::TimeService.current_time
 
-      url += "&phid=#{@phid}"
-      @full_graph = graph_service.load_graph(url: url)
+    url += "&phid=#{@phid}"
+    @full_graph = graph_service.load_graph(url: url)
 
-      access_end_dt = QaServer::TimeService.current_time
-      @access_time_s = access_end_dt - access_start_dt
-      @fetched_size = full_graph.triples.to_s.size if performance_data?
-      Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
-    end
+    access_end_dt = QaServer::TimeService.current_time
+    @access_time_s = access_end_dt - access_start_dt
+    @fetched_size = full_graph.triples.to_s.size if performance_data?
+    Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
+  end
 
-    def requested_results(full_results)
-      return full_results if @saved_performance_data
-      return full_results[:results] unless full_results.key? :response_header
-      full_results.delete(:performance)
-      full_results
-    end
+  def requested_results(full_results)
+    return full_results if @saved_performance_data
+    return full_results[:results] unless full_results.key? :response_header
+    full_results.delete(:performance)
+    full_results
+  end
 end

--- a/app/prepends/prepended_rdf/rdf_graph.rb
+++ b/app/prepends/prepended_rdf/rdf_graph.rb
@@ -46,12 +46,12 @@ module PrependedRdf::RdfGraph
     QaServer.config.performance_tracker.write "#{format('%.6f', end_time_s - start_time_s)}, " # load graph
   end
 
-  private
+private
 
-    def parse_phid(url)
-      i = url.rindex('&phid=')
-      phid = url[(i + 6)..url.length]
-      adjusted_url = url[0..(i - 1)]
-      [phid, adjusted_url]
-    end
+  def parse_phid(url)
+    i = url.rindex('&phid=')
+    phid = url[(i + 6)..url.length]
+    adjusted_url = url[0..(i - 1)]
+    [phid, adjusted_url]
+  end
 end

--- a/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_datatable_behavior.rb
@@ -116,44 +116,44 @@ module QaServer::MonitorStatus
       QaServer::TimeService.pretty_date(performance_data_end_dt)
     end
 
-    private
+  private
 
-      def expected_time_period
-        QaServer.config.performance_datatable_default_time_period
-      end
+    def expected_time_period
+      QaServer.config.performance_datatable_default_time_period
+    end
 
-      def data_table_for(authority_data, action)
-        authority_data[action]
-      end
+    def data_table_for(authority_data, action)
+      authority_data[action]
+    end
 
-      def unsupported_action?(stats)
-        values = stats.values
-        return true if values.all?(&:zero?)
-        values.any? { |v| v.respond_to?(:nan?) && v.nan? }
-      end
+    def unsupported_action?(stats)
+      values = stats.values
+      return true if values.all?(&:zero?)
+      values.any? { |v| v.respond_to?(:nan?) && v.nan? }
+    end
 
-      def format_stat(stats, idx)
-        return '' if stats[idx].nil? || unsupported_action?(stats)
-        format("%0.1f", stats[idx])
-      end
+    def format_stat(stats, idx)
+      return '' if stats[idx].nil? || unsupported_action?(stats)
+      format("%0.1f", stats[idx])
+    end
 
-      def performance_style_class(stats, stat_key)
-        return "status-not-supported" if unsupported_action?(stats)
-        return "status-bad" if max_threshold_exceeded(stats, stat_key)
-        return "status-unknown" if desired_threshold_not_met(stats, stat_key)
-        "status-good"
-      end
+    def performance_style_class(stats, stat_key)
+      return "status-not-supported" if unsupported_action?(stats)
+      return "status-bad" if max_threshold_exceeded(stats, stat_key)
+      return "status-unknown" if desired_threshold_not_met(stats, stat_key)
+      "status-good"
+    end
 
-      def max_threshold_exceeded(stats, stat_key)
-        return false if stats[stat_key].nil?
-        return true if stats[stat_key] > QaServer.config.performance_datatable_max_threshold
-        false
-      end
+    def max_threshold_exceeded(stats, stat_key)
+      return false if stats[stat_key].nil?
+      return true if stats[stat_key] > QaServer.config.performance_datatable_max_threshold
+      false
+    end
 
-      def desired_threshold_not_met(stats, stat_key)
-        return false if stats[stat_key].nil?
-        return true unless stats[stat_key] < QaServer.config.performance_datatable_warning_threshold
-        false
-      end
+    def desired_threshold_not_met(stats, stat_key)
+      return false if stats[stat_key].nil?
+      return true unless stats[stat_key] < QaServer.config.performance_datatable_warning_threshold
+      false
+    end
   end
 end

--- a/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
+++ b/app/presenters/concerns/qa_server/monitor_status/performance_graph_behavior.rb
@@ -83,73 +83,73 @@ module QaServer::MonitorStatus
       false
     end
 
-    private
+  private
 
-      def default_graph?(graph_info) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-        return false unless performance_all_actions_graph?(graph_info)
-        return true if QaServer.config.performance_graph_default_time_period == :day && performance_day_graph?(graph_info)
-        return true if QaServer.config.performance_graph_default_time_period == :month && performance_month_graph?(graph_info)
-        return true if QaServer.config.performance_graph_default_time_period == :year && performance_year_graph?(graph_info)
-        false
-      end
+    def default_graph?(graph_info) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      return false unless performance_all_actions_graph?(graph_info)
+      return true if QaServer.config.performance_graph_default_time_period == :day && performance_day_graph?(graph_info)
+      return true if QaServer.config.performance_graph_default_time_period == :month && performance_month_graph?(graph_info)
+      return true if QaServer.config.performance_graph_default_time_period == :year && performance_year_graph?(graph_info)
+      false
+    end
 
-      def performance_graphs_for_authority(graphs, auth_name)
-        [:search, :fetch, :all_actions].each do |action|
-          day_graph = performance_for_day_graph(auth_name, action)
-          month_graph = performance_for_month_graph(auth_name, action)
-          year_graph = performance_for_year_graph(auth_name, action)
-          add_graphs(graphs, day_graph, month_graph, year_graph)
-        end
+    def performance_graphs_for_authority(graphs, auth_name)
+      [:search, :fetch, :all_actions].each do |action|
+        day_graph = performance_for_day_graph(auth_name, action)
+        month_graph = performance_for_month_graph(auth_name, action)
+        year_graph = performance_for_year_graph(auth_name, action)
+        add_graphs(graphs, day_graph, month_graph, year_graph)
       end
+    end
 
-      # only add the graphs if all 3 exist
-      def add_graphs(graphs, day_graph, month_graph, year_graph)
-        return unless day_graph[:exists] && month_graph[:exists] && year_graph[:exists]
-        graphs << day_graph
-        graphs << month_graph
-        graphs << year_graph
-      end
+    # only add the graphs if all 3 exist
+    def add_graphs(graphs, day_graph, month_graph, year_graph)
+      return unless day_graph[:exists] && month_graph[:exists] && year_graph[:exists]
+      graphs << day_graph
+      graphs << month_graph
+      graphs << year_graph
+    end
 
-      def performance_for_day_graph(auth_name, action)
-        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :day)
-        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :day)
-        {
-          action: action,
-          time_period: :day,
-          graph: filepath,
-          exists: exists,
-          label: "Performance data for the last 24 hours.",
-          authority_name: auth_name,
-          base_id: "performance-of-#{auth_name}"
-        }
-      end
+    def performance_for_day_graph(auth_name, action)
+      filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :day)
+      exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :day)
+      {
+        action: action,
+        time_period: :day,
+        graph: filepath,
+        exists: exists,
+        label: "Performance data for the last 24 hours.",
+        authority_name: auth_name,
+        base_id: "performance-of-#{auth_name}"
+      }
+    end
 
-      def performance_for_month_graph(auth_name, action)
-        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :month)
-        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :month)
-        {
-          action: action,
-          time_period: :month,
-          graph: filepath,
-          exists: exists,
-          label: "Performance data for the last 30 days.",
-          authority_name: auth_name,
-          base_id: "performance-of-#{auth_name}"
-        }
-      end
+    def performance_for_month_graph(auth_name, action)
+      filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :month)
+      exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :month)
+      {
+        action: action,
+        time_period: :month,
+        graph: filepath,
+        exists: exists,
+        label: "Performance data for the last 30 days.",
+        authority_name: auth_name,
+        base_id: "performance-of-#{auth_name}"
+      }
+    end
 
-      def performance_for_year_graph(auth_name, action)
-        filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :year)
-        exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :year)
-        {
-          action: action,
-          time_period: :year,
-          graph: filepath,
-          exists: exists,
-          label: "Performance data for the last 12 months.",
-          authority_name: auth_name,
-          base_id: "performance-of-#{auth_name}"
-        }
-      end
+    def performance_for_year_graph(auth_name, action)
+      filepath = QaServer::PerformanceGraphingService.performance_graph_image_path(authority_name: auth_name, action: action, time_period: :year)
+      exists = QaServer::PerformanceGraphingService.performance_graph_image_exists?(authority_name: auth_name, action: action, time_period: :year)
+      {
+        action: action,
+        time_period: :year,
+        graph: filepath,
+        exists: exists,
+        label: "Performance data for the last 12 months.",
+        authority_name: auth_name,
+        base_id: "performance-of-#{auth_name}"
+      }
+    end
   end
 end

--- a/app/services/concerns/qa_server/gruff_graph.rb
+++ b/app/services/concerns/qa_server/gruff_graph.rb
@@ -5,24 +5,24 @@ require 'gruff'
 # This module include provides graph methods for generating graphs with Gruff
 module QaServer
   module GruffGraph
-    private
+  private
 
-      # common path for displaying and writing
-      def graph_relative_path
-        File.join('qa_server', 'charts')
-      end
+    # common path for displaying and writing
+    def graph_relative_path
+      File.join('qa_server', 'charts')
+    end
 
-      # used for displaying in a view with <image> tag
-      def graph_image_path
-        File.join('/', graph_relative_path)
-      end
+    # used for displaying in a view with <image> tag
+    def graph_image_path
+      File.join('/', graph_relative_path)
+    end
 
-      # used for writing out the file
-      def graph_full_path(graph_filename)
-        path = Rails.root.join('public', graph_relative_path)
-        # path = Rails.root.join('app', 'assets', 'images', graph_relative_path)
-        FileUtils.mkdir_p path
-        File.join(path, graph_filename)
-      end
+    # used for writing out the file
+    def graph_full_path(graph_filename)
+      path = Rails.root.join('public', graph_relative_path)
+      # path = Rails.root.join('app', 'assets', 'images', graph_relative_path)
+      FileUtils.mkdir_p path
+      File.join(path, graph_filename)
+    end
   end
 end

--- a/app/services/qa_server/authority_loader_service.rb
+++ b/app/services/qa_server/authority_loader_service.rb
@@ -22,24 +22,24 @@ module QaServer
         authority
       end
 
-      private
+    private
 
-        def authority_key(authority_name)
-          authority_name.upcase.to_sym
-        end
+      def authority_key(authority_name)
+        authority_name.upcase.to_sym
+      end
 
-        def load_authority(authority_name, status_log)
-          authority = Qa::Authorities::LinkedData::GenericAuthority.new(authority_key(authority_name))
-          if authority.blank?
-            if status_log.present?
-              status_log.add(authority_name: authority_name,
-                             status: QaServer::ScenarioValidator::FAIL,
-                             error_message: "Unable to load authority '#{authority_name}'; cause: UNKNOWN")
-            end
-            return nil
+      def load_authority(authority_name, status_log)
+        authority = Qa::Authorities::LinkedData::GenericAuthority.new(authority_key(authority_name))
+        if authority.blank?
+          if status_log.present?
+            status_log.add(authority_name: authority_name,
+                           status: QaServer::ScenarioValidator::FAIL,
+                           error_message: "Unable to load authority '#{authority_name}'; cause: UNKNOWN")
           end
-          authority
+          return nil
         end
+        authority
+      end
     end
   end
 end

--- a/app/services/qa_server/database_migrator.rb
+++ b/app/services/qa_server/database_migrator.rb
@@ -50,22 +50,22 @@ module QaServer
       end
     end
 
-    private
+  private
 
-      def migrations
-        Dir.chdir(self.class.migrations_dir) { Dir.glob('db/migrate/[0-9]*_*.rb.erb') }.sort
-      end
+    def migrations
+      Dir.chdir(self.class.migrations_dir) { Dir.glob('db/migrate/[0-9]*_*.rb.erb') }.sort
+    end
 
-      def parse_basename_from(filename)
-        # Add engine name to filename to mimic ``ActiveRecord::Migration.copy` behavior
-        filename.slice(/(?<dateprefix>\d)+_(?<basename>.+)\.erb/, 'basename').sub('.', '.qa_server.')
-      end
+    def parse_basename_from(filename)
+      # Add engine name to filename to mimic ``ActiveRecord::Migration.copy` behavior
+      filename.slice(/(?<dateprefix>\d)+_(?<basename>.+)\.erb/, 'basename').sub('.', '.qa_server.')
+    end
 
-      def migration_version
-        # Don't use AR migration versioning in Rails 4
-        return if Rails.version < '5.0.0'
-        # Specify the current major.minor version of Rails for AR migrations
-        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
-      end
+    def migration_version
+      # Don't use AR migration versioning in Rails 4
+      return if Rails.version < '5.0.0'
+      # Specify the current major.minor version of Rails for AR migrations
+      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+    end
   end
 end

--- a/app/services/qa_server/history_graphing_service.rb
+++ b/app/services/qa_server/history_graphing_service.rb
@@ -29,41 +29,41 @@ module QaServer
         QaServer.config.monitor_logger.warn("FAILED to write historical graph at #{history_graph_image_path}") unless history_graph_image_exists?
       end
 
-      private
+    private
 
-        def create_gruff_graph(reworked_data, full_path)
-          g = Gruff::SideStackedBar.new
-          historical_graph_theme(g)
-          g.labels = reworked_data[0]
-          g.data('Fail', reworked_data[1])
-          g.data('Pass', reworked_data[2])
-          g.write full_path
-        end
+      def create_gruff_graph(reworked_data, full_path)
+        g = Gruff::SideStackedBar.new
+        historical_graph_theme(g)
+        g.labels = reworked_data[0]
+        g.data('Fail', reworked_data[1])
+        g.data('Pass', reworked_data[2])
+        g.write full_path
+      end
 
-        def historical_graph_theme(g)
-          g.theme_pastel
-          g.colors = ['#ffcccc', '#ccffcc']
-          g.marker_font_size = 12
-          g.x_axis_increment = 10
-        end
+      def historical_graph_theme(g)
+        g.theme_pastel
+        g.colors = ['#ffcccc', '#ccffcc']
+        g.marker_font_size = 12
+        g.x_axis_increment = 10
+      end
 
-        def historical_graph_full_path
-          graph_full_path(HISTORICAL_GRAPH_FILENAME)
-        end
+      def historical_graph_full_path
+        graph_full_path(HISTORICAL_GRAPH_FILENAME)
+      end
 
-        def rework_historical_data_for_gruff(data)
-          labels = {}
-          pass_data = []
-          fail_data = []
-          i = 0
-          data.each do |authname, authdata|
-            labels[i] = authname
-            i += 1
-            fail_data << authdata[:bad]
-            pass_data << authdata[:good]
-          end
-          [labels, fail_data, pass_data]
+      def rework_historical_data_for_gruff(data)
+        labels = {}
+        pass_data = []
+        fail_data = []
+        i = 0
+        data.each do |authname, authdata|
+          labels[i] = authname
+          i += 1
+          fail_data << authdata[:bad]
+          pass_data << authdata[:good]
         end
+        [labels, fail_data, pass_data]
+      end
     end
   end
 end

--- a/app/services/qa_server/performance_calculator_service.rb
+++ b/app/services/qa_server/performance_calculator_service.rb
@@ -40,85 +40,85 @@ module QaServer
       stats
     end
 
-    private
+  private
 
-      def calculate_load_stats(avg, low, high)
-        stats[AVG_LOAD] = calculate_average(full_load_times) if avg
-        stats[LOW_LOAD] = calculate_10th_percentile(full_load_times) if low
-        stats[HIGH_LOAD] = calculate_90th_percentile(full_load_times) if high
-      end
+    def calculate_load_stats(avg, low, high)
+      stats[AVG_LOAD] = calculate_average(full_load_times) if avg
+      stats[LOW_LOAD] = calculate_10th_percentile(full_load_times) if low
+      stats[HIGH_LOAD] = calculate_90th_percentile(full_load_times) if high
+    end
 
-      def calculate_retrieve_stats(avg, low, high)
-        stats[AVG_RETR] = calculate_average(retrieve_times) if avg
-        stats[LOW_RETR] = calculate_10th_percentile(retrieve_times) if low
-        stats[HIGH_RETR] = calculate_90th_percentile(retrieve_times) if high
-      end
+    def calculate_retrieve_stats(avg, low, high)
+      stats[AVG_RETR] = calculate_average(retrieve_times) if avg
+      stats[LOW_RETR] = calculate_10th_percentile(retrieve_times) if low
+      stats[HIGH_RETR] = calculate_90th_percentile(retrieve_times) if high
+    end
 
-      def calculate_graph_load_stats(avg, low, high)
-        stats[AVG_GRPH] = calculate_average(graph_load_times) if avg
-        stats[LOW_GRPH] = calculate_10th_percentile(graph_load_times) if low
-        stats[HIGH_GRPH] = calculate_90th_percentile(graph_load_times) if high
-      end
+    def calculate_graph_load_stats(avg, low, high)
+      stats[AVG_GRPH] = calculate_average(graph_load_times) if avg
+      stats[LOW_GRPH] = calculate_10th_percentile(graph_load_times) if low
+      stats[HIGH_GRPH] = calculate_90th_percentile(graph_load_times) if high
+    end
 
-      def calculate_normalization_stats(avg, low, high)
-        stats[AVG_NORM] = calculate_average(norm_times) if avg
-        stats[LOW_NORM] = calculate_10th_percentile(norm_times) if low
-        stats[HIGH_NORM] = calculate_90th_percentile(norm_times) if high
-      end
+    def calculate_normalization_stats(avg, low, high)
+      stats[AVG_NORM] = calculate_average(norm_times) if avg
+      stats[LOW_NORM] = calculate_10th_percentile(norm_times) if low
+      stats[HIGH_NORM] = calculate_90th_percentile(norm_times) if high
+    end
 
-      def calculate_action_stats(avg, low, high)
-        stats[AVG_ACTN] = calculate_average(action_times) if avg
-        stats[LOW_ACTN] = calculate_10th_percentile(action_times) if low
-        stats[HIGH_ACTN] = calculate_90th_percentile(action_times) if high
-      end
+    def calculate_action_stats(avg, low, high)
+      stats[AVG_ACTN] = calculate_average(action_times) if avg
+      stats[LOW_ACTN] = calculate_10th_percentile(action_times) if low
+      stats[HIGH_ACTN] = calculate_90th_percentile(action_times) if high
+    end
 
-      def tenth_percentile_count(times)
-        percentile_count = (times.count * 0.1).round
-        percentile_count = 1 if percentile_count.zero? && times.count > 1
-        percentile_count
-      end
+    def tenth_percentile_count(times)
+      percentile_count = (times.count * 0.1).round
+      percentile_count = 1 if percentile_count.zero? && times.count > 1
+      percentile_count
+    end
 
-      def times(column)
-        where_clause = action.nil? ? "" : { "action" => action }
-        records.where(where_clause).where.not(column => nil).order(column).pluck(column)
-      end
+    def times(column)
+      where_clause = action.nil? ? "" : { "action" => action }
+      records.where(where_clause).where.not(column => nil).order(column).pluck(column)
+    end
 
-      def full_load_times
-        @full_load_times ||= times(:retrieve_plus_graph_load_time_ms)
-      end
+    def full_load_times
+      @full_load_times ||= times(:retrieve_plus_graph_load_time_ms)
+    end
 
-      def retrieve_times
-        @retrieve_times ||= times(:retrieve_time_ms)
-      end
+    def retrieve_times
+      @retrieve_times ||= times(:retrieve_time_ms)
+    end
 
-      def graph_load_times
-        @graph_load_times ||= times(:graph_load_time_ms)
-      end
+    def graph_load_times
+      @graph_load_times ||= times(:graph_load_time_ms)
+    end
 
-      def norm_times
-        @norm_times ||= times(:normalization_time_ms)
-      end
+    def norm_times
+      @norm_times ||= times(:normalization_time_ms)
+    end
 
-      def action_times
-        @action_times ||= times(:action_time_ms)
-      end
+    def action_times
+      @action_times ||= times(:action_time_ms)
+    end
 
-      def calculate_average(times)
-        return 0 if times.count.zero?
-        return times[0] if times.count == 1
-        times.inject(0.0) { |sum, el| sum + el } / times.count
-      end
+    def calculate_average(times)
+      return 0 if times.count.zero?
+      return times[0] if times.count == 1
+      times.inject(0.0) { |sum, el| sum + el } / times.count
+    end
 
-      def calculate_10th_percentile(times)
-        return 0 if times.count.zero?
-        return times[0] if times.count == 1
-        times[tenth_percentile_count(times) - 1]
-      end
+    def calculate_10th_percentile(times)
+      return 0 if times.count.zero?
+      return times[0] if times.count == 1
+      times[tenth_percentile_count(times) - 1]
+    end
 
-      def calculate_90th_percentile(times)
-        return 0 if times.count.zero?
-        return times[0] if times.count == 1
-        times[times.count - tenth_percentile_count(times)]
-      end
+    def calculate_90th_percentile(times)
+      return 0 if times.count.zero?
+      return times[0] if times.count == 1
+      times[times.count - tenth_percentile_count(times)]
+    end
   end
 end

--- a/app/services/qa_server/performance_datatable_service.rb
+++ b/app/services/qa_server/performance_datatable_service.rb
@@ -32,48 +32,48 @@ module QaServer
         end
       end
 
-      private
+    private
 
-        def datatable_data_for_authority(authority_name: nil)
-          [:search, :fetch, :all_actions].each_with_object({}) do |action, hash|
-            hash[action] = data_table_stats(authority_name, action)
-          end
+      def datatable_data_for_authority(authority_name: nil)
+        [:search, :fetch, :all_actions].each_with_object({}) do |action, hash|
+          hash[action] = data_table_stats(authority_name, action)
         end
+      end
 
-        # Get statistics for data table.
-        # @param auth_name [String] limit statistics to records for the given authority (default: all authorities)
-        # @param action [Symbol] one of :search, :fetch, :all_actions
-        # @returns [Hash] performance statistics for the datatable during the expected time period
-        # @example
-        #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
-        #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
-        #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
-        def data_table_stats(auth_name, action)
-          records = records_for_authority(auth_name)
-          stats_calculator_class.new(records, action: action).calculate_stats_with_percentiles
-        end
+      # Get statistics for data table.
+      # @param auth_name [String] limit statistics to records for the given authority (default: all authorities)
+      # @param action [Symbol] one of :search, :fetch, :all_actions
+      # @returns [Hash] performance statistics for the datatable during the expected time period
+      # @example
+      #   { retrieve_avg_ms: 12.3, graph_load_avg_ms: 2.1, normalization_avg_ms: 4.2, full_request_avg_ms: 16.5,
+      #     retrieve_10th_ms: 12.3, graph_load_10th_ms: 12.3, normalization_10th_ms: 4.2, full_request_10th_ms: 16.5,
+      #     retrieve_90th_ms: 12.3, graph_load_90th_ms: 12.3, normalization_90th_ms: 4.2, full_request_90th_ms: 16.5 }
+      def data_table_stats(auth_name, action)
+        records = records_for_authority(auth_name)
+        stats_calculator_class.new(records, action: action).calculate_stats_with_percentiles
+      end
 
-        def expected_time_period
-          QaServer.config.performance_datatable_default_time_period
-        end
+      def expected_time_period
+        QaServer.config.performance_datatable_default_time_period
+      end
 
-        def records_for_authority(auth_name)
-          case expected_time_period
-          when :day
-            QaServer.config.performance_cache.write_all # only need to write if just using today's data
-            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_24_hours(auth_name: auth_name))
-          when :month
-            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_30_days(auth_name: auth_name))
-          when :year
-            performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_12_months(auth_name: auth_name))
-          else
-            all_records(auth_name)
-          end
+      def records_for_authority(auth_name)
+        case expected_time_period
+        when :day
+          QaServer.config.performance_cache.write_all # only need to write if just using today's data
+          performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_24_hours(auth_name: auth_name))
+        when :month
+          performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_30_days(auth_name: auth_name))
+        when :year
+          performance_data_class.where(QaServer::TimePeriodService.where_clause_for_last_12_months(auth_name: auth_name))
+        else
+          all_records(auth_name)
         end
+      end
 
-        def all_records(auth_name)
-          auth_name.nil? ? performance_data_class.all : performance_data_class.where(authority: auth_name)
-        end
+      def all_records(auth_name)
+        auth_name.nil? ? performance_data_class.all : performance_data_class.where(authority: auth_name)
+      end
     end
   end
 end

--- a/app/services/qa_server/performance_graph_data_service.rb
+++ b/app/services/qa_server/performance_graph_data_service.rb
@@ -88,39 +88,39 @@ module QaServer
         averages
       end
 
-      private
+    private
 
-        def records_by(authority_name, action, time_period)
-          where_clause = { dt_stamp: time_period }
-          where_clause[:authority] = authority_name unless authority_name.nil? || authority_name == ALL_AUTH
-          where_clause[:action] = action unless action.nil? || action == ALL_ACTIONS
-          performance_data_class.where(where_clause)
-        end
+      def records_by(authority_name, action, time_period)
+        where_clause = { dt_stamp: time_period }
+        where_clause[:authority] = authority_name unless authority_name.nil? || authority_name == ALL_AUTH
+        where_clause[:action] = action unless action.nil? || action == ALL_ACTIONS
+        performance_data_class.where(where_clause)
+      end
 
-        def performance_by_hour_label(idx, start_hour)
-          if idx == 23
-            I18n.t('qa_server.monitor_status.performance.now')
-          elsif ((idx + 1) % 2).zero?
-            (start_hour.hour * 100).to_s
-          else
-            " "
-          end
+      def performance_by_hour_label(idx, start_hour)
+        if idx == 23
+          I18n.t('qa_server.monitor_status.performance.now')
+        elsif ((idx + 1) % 2).zero?
+          (start_hour.hour * 100).to_s
+        else
+          " "
         end
+      end
 
-        def performance_by_day_label(idx, start_day)
-          if idx == 29
-            I18n.t('qa_server.monitor_status.performance.today')
-          elsif ((idx + 1) % 5).zero?
-            start_day.strftime("%m-%d")
-          else
-            " "
-          end
+      def performance_by_day_label(idx, start_day)
+        if idx == 29
+          I18n.t('qa_server.monitor_status.performance.today')
+        elsif ((idx + 1) % 5).zero?
+          start_day.strftime("%m-%d")
+        else
+          " "
         end
+      end
 
-        def calculate_from_records(records, range_idx, range_label)
-          stats = stats_calculator_class.new(records).calculate_average_stats
-          { STATS => stats, range_idx => range_label }
-        end
+      def calculate_from_records(records, range_idx, range_label)
+        stats = stats_calculator_class.new(records).calculate_average_stats
+        { STATS => stats, range_idx => range_label }
+      end
     end
   end
 end

--- a/app/services/qa_server/performance_graphing_service.rb
+++ b/app/services/qa_server/performance_graphing_service.rb
@@ -63,69 +63,69 @@ module QaServer
                            I18n.t('qa_server.monitor_status.performance.x_axis_hour'))
       end
 
-      private
+    private
 
-        def performance_graph_full_path(authority_name, action, time_period)
-          graph_full_path(graph_filename(authority_name, action, time_period))
-        end
+      def performance_graph_full_path(authority_name, action, time_period)
+        graph_full_path(graph_filename(authority_name, action, time_period))
+      end
 
-        def graph_filename(authority_name, action, time_period)
-          "performance_of_#{authority_name}_#{action}_for_#{time_period}_graph.png"
-        end
+      def graph_filename(authority_name, action, time_period)
+        "performance_of_#{authority_name}_#{action}_for_#{time_period}_graph.png"
+      end
 
-        def rework_performance_data_for_gruff(performance_data, label_key)
-          labels = {}
-          # full_load_data = []
-          retrieve_data = []
-          graph_load_data = []
-          normalization_data = []
-          performance_data.each do |i, data|
-            labels[i] = data[label_key]
-            retrieve_data << data[STATS][AVG_RETR]
-            graph_load_data << graph_load_time(data)
-            normalization_data << data[STATS][AVG_NORM]
-          end
-          [labels, retrieve_data, graph_load_data, normalization_data]
+      def rework_performance_data_for_gruff(performance_data, label_key)
+        labels = {}
+        # full_load_data = []
+        retrieve_data = []
+        graph_load_data = []
+        normalization_data = []
+        performance_data.each do |i, data|
+          labels[i] = data[label_key]
+          retrieve_data << data[STATS][AVG_RETR]
+          graph_load_data << graph_load_time(data)
+          normalization_data << data[STATS][AVG_NORM]
         end
+        [labels, retrieve_data, graph_load_data, normalization_data]
+      end
 
-        def graph_load_time(data)
-          # For some sense of backward compatibility and to avoid losing the usefulness of previously collected data,
-          # create the graph using the old :load stat when both :retrieve and :graph_load are 0. If the value truly
-          # is 0, then :load will also be 0.
-          # NOTE: It's ok to use AVG_RETR for the retrieve data point because it is 0.
-          # rubocop:disable Style/TernaryParentheses
-          (data[STATS][AVG_RETR].zero? && data[STATS][AVG_GRPH].zero?) ? data[STATS][AVG_LOAD] : data[STATS][AVG_GRPH]
-          # rubocop:enable Style/TernaryParentheses
-        end
+      def graph_load_time(data)
+        # For some sense of backward compatibility and to avoid losing the usefulness of previously collected data,
+        # create the graph using the old :load stat when both :retrieve and :graph_load are 0. If the value truly
+        # is 0, then :load will also be 0.
+        # NOTE: It's ok to use AVG_RETR for the retrieve data point because it is 0.
+        # rubocop:disable Style/TernaryParentheses
+        (data[STATS][AVG_RETR].zero? && data[STATS][AVG_GRPH].zero?) ? data[STATS][AVG_LOAD] : data[STATS][AVG_GRPH]
+        # rubocop:enable Style/TernaryParentheses
+      end
 
-        def performance_graph_theme(g, x_axis_label)
-          g.theme_pastel
-          g.colors = [QaServer.config.performance_normalization_color,
-                      QaServer.config.performance_graph_load_color,
-                      QaServer.config.performance_retrieve_color]
-          g.marker_font_size = 12
-          g.x_axis_increment = 10
-          g.x_axis_label = x_axis_label
-          g.y_axis_label = I18n.t('qa_server.monitor_status.performance.y_axis_ms')
-          g.minimum_value = 0
-          g.maximum_value = QaServer.config.performance_y_axis_max
-        end
+      def performance_graph_theme(g, x_axis_label)
+        g.theme_pastel
+        g.colors = [QaServer.config.performance_normalization_color,
+                    QaServer.config.performance_graph_load_color,
+                    QaServer.config.performance_retrieve_color]
+        g.marker_font_size = 12
+        g.x_axis_increment = 10
+        g.x_axis_label = x_axis_label
+        g.y_axis_label = I18n.t('qa_server.monitor_status.performance.y_axis_ms')
+        g.minimum_value = 0
+        g.maximum_value = QaServer.config.performance_y_axis_max
+      end
 
-        def create_gruff_graph(performance_data, performance_graph_full_path, x_axis_label)
-          g = Gruff::StackedBar.new
-          performance_graph_theme(g, x_axis_label)
-          g.labels = performance_data[0]
-          g.data(I18n.t('qa_server.monitor_status.performance.retrieve_time_ms'), performance_data[1])
-          g.data(I18n.t('qa_server.monitor_status.performance.graph_load_time_ms'), performance_data[2])
-          g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[3])
-          g.write performance_graph_full_path
-        end
+      def create_gruff_graph(performance_data, performance_graph_full_path, x_axis_label)
+        g = Gruff::StackedBar.new
+        performance_graph_theme(g, x_axis_label)
+        g.labels = performance_data[0]
+        g.data(I18n.t('qa_server.monitor_status.performance.retrieve_time_ms'), performance_data[1])
+        g.data(I18n.t('qa_server.monitor_status.performance.graph_load_time_ms'), performance_data[2])
+        g.data(I18n.t('qa_server.monitor_status.performance.normalization_time_ms'), performance_data[3])
+        g.write performance_graph_full_path
+      end
 
-        def log_failure(authority_name, action, time_period)
-          relative_path = performance_graph_image_path(authority_name: authority_name, action: action, time_period: time_period)
-          exists = performance_graph_image_exists?(authority_name: authority_name, action: action, time_period: time_period)
-          QaServer.config.monitor_logger.warn("FAILED to write performance graph at #{relative_path}") unless exists
-        end
+      def log_failure(authority_name, action, time_period)
+        relative_path = performance_graph_image_path(authority_name: authority_name, action: action, time_period: time_period)
+        exists = performance_graph_image_exists?(authority_name: authority_name, action: action, time_period: time_period)
+        QaServer.config.monitor_logger.warn("FAILED to write performance graph at #{relative_path}") unless exists
+      end
     end
   end
 end

--- a/app/services/qa_server/performance_per_byte_calculator_service.rb
+++ b/app/services/qa_server/performance_per_byte_calculator_service.rb
@@ -36,53 +36,53 @@ module QaServer
       stats
     end
 
-    private
+  private
 
-      def extract_bytes
-        stats[SRC_BYTES] = retrieve_data.count.zero? ? 0 : retrieve_data.map { |d| d[BYTES] }
-      end
+    def extract_bytes
+      stats[SRC_BYTES] = retrieve_data.count.zero? ? 0 : retrieve_data.map { |d| d[BYTES] }
+    end
 
-      def calculate_retrieve_stats
-        stats[BPMS_RETR] = calculate_bytes_per_ms(retrieve_data)
-        stats[MSPB_RETR] = calculate_ms_per_byte(retrieve_data)
-      end
+    def calculate_retrieve_stats
+      stats[BPMS_RETR] = calculate_bytes_per_ms(retrieve_data)
+      stats[MSPB_RETR] = calculate_ms_per_byte(retrieve_data)
+    end
 
-      def calculate_graph_load_stats
-        stats[BPMS_GRPH] = calculate_bytes_per_ms(graph_load_data)
-        stats[MSPB_GRPH] = calculate_ms_per_byte(graph_load_data)
-      end
+    def calculate_graph_load_stats
+      stats[BPMS_GRPH] = calculate_bytes_per_ms(graph_load_data)
+      stats[MSPB_GRPH] = calculate_ms_per_byte(graph_load_data)
+    end
 
-      def calculate_normalization_stats
-        stats[BPMS_NORM] = calculate_bytes_per_ms(norm_data)
-        stats[MSPB_NORM] = calculate_ms_per_byte(norm_data)
-      end
+    def calculate_normalization_stats
+      stats[BPMS_NORM] = calculate_bytes_per_ms(norm_data)
+      stats[MSPB_NORM] = calculate_ms_per_byte(norm_data)
+    end
 
-      def calculate_bytes_per_ms(data)
-        return 0 if data.count.zero?
-        return data[0][BYTES] / d[0][TIME] if data.count == 1
-        data.map { |d| d[BYTES] / d[TIME] }
-      end
+    def calculate_bytes_per_ms(data)
+      return 0 if data.count.zero?
+      return data[0][BYTES] / d[0][TIME] if data.count == 1
+      data.map { |d| d[BYTES] / d[TIME] }
+    end
 
-      def calculate_ms_per_byte(data)
-        return 0 if data.count.zero?
-        return data[0][TIME] / d[0][BYTES] if data.count == 1
-        data.map { |d| d[TIME] / d[BYTES] }
-      end
+    def calculate_ms_per_byte(data)
+      return 0 if data.count.zero?
+      return data[0][TIME] / d[0][BYTES] if data.count == 1
+      data.map { |d| d[TIME] / d[BYTES] }
+    end
 
-      def data(column)
-        records.where.not(column => nil).order(dt_stamp: :desc).limit(n).pluck(column, :size_bytes)
-      end
+    def data(column)
+      records.where.not(column => nil).order(dt_stamp: :desc).limit(n).pluck(column, :size_bytes)
+    end
 
-      def retrieve_data
-        @retrieve_data ||= data(:retrieve_time_ms)
-      end
+    def retrieve_data
+      @retrieve_data ||= data(:retrieve_time_ms)
+    end
 
-      def graph_load_data
-        @graph_data ||= data(:graph_load_time_ms)
-      end
+    def graph_load_data
+      @graph_data ||= data(:graph_load_time_ms)
+    end
 
-      def norm_data
-        @norm_data ||= data(:normalization_time_ms)
-      end
+    def norm_data
+      @norm_data ||= data(:normalization_time_ms)
+    end
   end
 end

--- a/app/services/qa_server/performance_per_byte_data_service.rb
+++ b/app/services/qa_server/performance_per_byte_data_service.rb
@@ -28,14 +28,14 @@ module QaServer
         stats_calculator_class.new(records: records, n: n).calculate
       end
 
-      private
+    private
 
-        def records_by(authority_name, action)
-          where_clause = {}
-          where_clause[:authority] = authority_name unless authority_name.nil? || authority_name == ALL_AUTH
-          where_clause[:action] = action unless action.nil? || action == ALL_ACTIONS
-          performance_data_class.where(where_clause)
-        end
+      def records_by(authority_name, action)
+        where_clause = {}
+        where_clause[:authority] = authority_name unless authority_name.nil? || authority_name == ALL_AUTH
+        where_clause[:action] = action unless action.nil? || action == ALL_ACTIONS
+        performance_data_class.where(where_clause)
+      end
     end
   end
 end

--- a/app/services/qa_server/scenarios_loader_service.rb
+++ b/app/services/qa_server/scenarios_loader_service.rb
@@ -32,7 +32,7 @@ module QaServer
 
     def self.load_config(authority_name, status_log)
       scenarios_config = YAML.load_file(scenario_path(authority_name))
-      unless scenarios_config.present?
+      if scenarios_config.blank?
         status_log.add(authority_name: authority_name,
                        status: QaServer::ScenarioValidator::FAIL,
                        error_message: "Unable to load scenarios for authority '#{authority_name}'; cause: UNKNOWN")

--- a/app/services/qa_server/time_period_service.rb
+++ b/app/services/qa_server/time_period_service.rb
@@ -63,31 +63,31 @@ module QaServer
         where_with_authority(where_clause, auth_name, auth_table)
       end
 
-      private
+    private
 
-        def where_for_dt_stamp(dt_table, dt_column, time_period)
-          end_range = QaServer::TimeService.current_time
-          start_range = end_range - time_period
-          where_clause = { dt_column => start_range..end_range }
-          where_clause = { dt_table => where_clause } unless dt_table.nil?
-          where_clause
-        end
+      def where_for_dt_stamp(dt_table, dt_column, time_period)
+        end_range = QaServer::TimeService.current_time
+        start_range = end_range - time_period
+        where_clause = { dt_column => start_range..end_range }
+        where_clause = { dt_table => where_clause } unless dt_table.nil?
+        where_clause
+      end
 
-        def where_with_authority(where_clause, auth_name, auth_table)
-          return where_clause if auth_name.nil?
-          if auth_table.nil?
-            where_clause[:authority] = auth_name
-          else
-            where_clause[auth_table] = { authority: auth_name }
-          end
-          where_clause
+      def where_with_authority(where_clause, auth_name, auth_table)
+        return where_clause if auth_name.nil?
+        if auth_table.nil?
+          where_clause[:authority] = auth_name
+        else
+          where_clause[auth_table] = { authority: auth_name }
         end
+        where_clause
+      end
 
-        def validate_params(auth_name, auth_table, dt_table)
-          raise ArgumentError, "Do not specify auth_table when auth_name is not specified" if auth_table.present? && auth_name.nil?
-          return if auth_name.nil?
-          raise ArgumentError, "Either both table names need to be specified or neither" if auth_table.present? ^ dt_table.present?
-        end
+      def validate_params(auth_name, auth_table, dt_table)
+        raise ArgumentError, "Do not specify auth_table when auth_name is not specified" if auth_table.present? && auth_name.nil?
+        return if auth_name.nil?
+        raise ArgumentError, "Either both table names need to be specified or neither" if auth_table.present? ^ dt_table.present?
+      end
     end
   end
 end

--- a/app/validators/qa_server/scenario_validator.rb
+++ b/app/validators/qa_server/scenario_validator.rb
@@ -34,103 +34,103 @@ module QaServer
       log
     end
 
-    private
+  private
 
-      # Log the structure of the scenario and status of a test run.
-      # @param [Hash] status_info holding information to be logged
-      # @see QaServer::ScenarioLogger
-      def log(status_info = {})
-        status_info[:authority_name] = authority_name
-        status_info[:validation_type] = scenario_validation_type
-        status_info[:subauth] = subauthority_name
-        status_info[:service] = service
-        status_info[:action] = action
-        status_info[:url] = url
-        status_info[:request_data] = request_data
-        status_log.add(status_info)
-      end
+    # Log the structure of the scenario and status of a test run.
+    # @param [Hash] status_info holding information to be logged
+    # @see QaServer::ScenarioLogger
+    def log(status_info = {})
+      status_info[:authority_name] = authority_name
+      status_info[:validation_type] = scenario_validation_type
+      status_info[:subauth] = subauthority_name
+      status_info[:service] = service
+      status_info[:action] = action
+      status_info[:url] = url
+      status_info[:request_data] = request_data
+      status_log.add(status_info)
+    end
 
-      def run_accuracy_scenario
-        # ABSTRACT - must be implemented by scenario validator for specific types
-      end
+    def run_accuracy_scenario
+      # ABSTRACT - must be implemented by scenario validator for specific types
+    end
 
-      def run_connection_scenario
-        # ABSTRACT - must be implemented by scenario validator for specific types
-      end
+    def run_connection_scenario
+      # ABSTRACT - must be implemented by scenario validator for specific types
+    end
 
-      def request_data
-        # ABSTRACT - must be implemented by scenario validator for specific types
-      end
+    def request_data
+      # ABSTRACT - must be implemented by scenario validator for specific types
+    end
 
-      # Runs the test in the block passed by the specific scenario type.
-      # @return [Symbol] :good (PASS) or :unknown (UNKNOWN) based on whether enough results were returned
-      def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
-        dt_start = QaServer::TimeService.current_time
-        results = yield if block_given?
-        dt_end = QaServer::TimeService.current_time
-        actual_size = results.to_s.length
-        status = actual_size > min_expected_size ? PASS : UNKNOWN
-        errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
-        log(status: status, error_message: errmsg, normalization_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
-      rescue Exception => e
-        dt_end = QaServer::TimeService.current_time
-        log(status: FAIL, error_message: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
-      end
+    # Runs the test in the block passed by the specific scenario type.
+    # @return [Symbol] :good (PASS) or :unknown (UNKNOWN) based on whether enough results were returned
+    def test_connection(min_expected_size: MIN_EXPECTED_SIZE, scenario_type_name:)
+      dt_start = QaServer::TimeService.current_time
+      results = yield if block_given?
+      dt_end = QaServer::TimeService.current_time
+      actual_size = results.to_s.length
+      status = actual_size > min_expected_size ? PASS : UNKNOWN
+      errmsg = status == PASS ? '' : "#{scenario_type_name.capitalize} scenario unknown status; cause: Results actual size (#{actual_size} < expected size (#{min_expected_size})"
+      log(status: status, error_message: errmsg, normalization_run_time: (dt_end - dt_start)) # TODO: need to get run times from results
+    rescue Exception => e
+      dt_end = QaServer::TimeService.current_time
+      log(status: FAIL, error_message: "Exception executing #{scenario_type_name} scenario; cause: #{e.message}", request_run_time: (dt_end - dt_start))
+    end
 
-      # @return [Qa::Authorities::LinkedData::GenericAuthority] authority instance the scenarios run against
-      def authority
-        scenario.authority
-      end
+    # @return [Qa::Authorities::LinkedData::GenericAuthority] authority instance the scenarios run against
+    def authority
+      scenario.authority
+    end
 
-      # @return [Symbol] name of the authority (e.g. :CERL_LD4L_CACHE)
-      def authority_name
-        scenario.authority_name.upcase
-      end
+    # @return [Symbol] name of the authority (e.g. :CERL_LD4L_CACHE)
+    def authority_name
+      scenario.authority_name.upcase
+    end
 
-      # @return [String] name of the subauthority (e.g. "person")
-      def subauthority_name
-        scenario.subauthority_name
-      end
+    # @return [String] name of the subauthority (e.g. "person")
+    def subauthority_name
+      scenario.subauthority_name
+    end
 
-      # @return [String] service providing the data (e.g. "ld4l_cache" or "direct")
-      def service
-        scenario.service
-      end
+    # @return [String] service providing the data (e.g. "ld4l_cache" or "direct")
+    def service
+      scenario.service
+    end
 
-      # @return [String] relative URL with ready to execute (e.g. ""/authorities/search/linked_data/cerl_ld4l_cache/person?q=office")
-      def url
-        scenario.url
-      end
+    # @return [String] relative URL with ready to execute (e.g. ""/authorities/search/linked_data/cerl_ld4l_cache/person?q=office")
+    def url
+      scenario.url
+    end
 
-      # @return [String] action being tested (e.g. "search" or "term")
-      def action
-        # ABSTRACT - must be implemented by scenario validator for specific types
-      end
+    # @return [String] action being tested (e.g. "search" or "term")
+    def action
+      # ABSTRACT - must be implemented by scenario validator for specific types
+    end
 
-      def scenario_validation_type
-        return VALIDATE_CONNECTION if connection_scenario?
-        return VALIDATE_ACCURACY if accuracy_scenario?
-        nil
-      end
+    def scenario_validation_type
+      return VALIDATE_CONNECTION if connection_scenario?
+      return VALIDATE_ACCURACY if accuracy_scenario?
+      nil
+    end
 
-      def validating_connections?
-        return true if validation_type == VALIDATE_CONNECTION || validation_type == ALL_VALIDATIONS
-        false
-      end
+    def validating_connections?
+      return true if validation_type == VALIDATE_CONNECTION || validation_type == ALL_VALIDATIONS
+      false
+    end
 
-      def validating_accuracy?
-        return true if [VALIDATE_ACCURACY, VALIDATE_ACCURACY_COMPARISON, ALL_VALIDATIONS].include? validation_type
-        false
-      end
+    def validating_accuracy?
+      return true if [VALIDATE_ACCURACY, VALIDATE_ACCURACY_COMPARISON, ALL_VALIDATIONS].include? validation_type
+      false
+    end
 
-      def accuracy_scenario?
-        # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
-        false
-      end
+    def accuracy_scenario?
+      # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
+      false
+    end
 
-      def connection_scenario?
-        # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
-        false
-      end
+    def connection_scenario?
+      # ABSTRACT define in specific scenario type validator (i.e. QaServer::TermScenarioValidator, QaServer::SearchScenarioValidator)
+      false
+    end
   end
 end

--- a/app/validators/qa_server/search_scenario_validator.rb
+++ b/app/validators/qa_server/search_scenario_validator.rb
@@ -18,81 +18,81 @@ module QaServer
       @request_data = scenario.query
     end
 
-    private
+  private
 
-      def action
-        SEARCH_ACTION
+    def action
+      SEARCH_ACTION
+    end
+
+    # CONCRETE Implementation: Run the connection test and log results
+    def run_connection_scenario
+      test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'search') do
+        replacements = scenario.replacements.dup
+        authority.search(scenario.query,
+                         subauth: scenario.subauthority_name,
+                         replacements: replacements)
+      end
+    end
+
+    # CONCRETE Implementation: Run the accuracy test and log results
+    def run_accuracy_scenario
+      test_accuracy(subject_uri: scenario.subject_uri, expected_by_position: scenario.expected_by_position, pending: scenario.pending?) do
+        replacements = scenario.replacements.dup
+        authority.search(scenario.query,
+                         subauth: scenario.subauthority_name,
+                         replacements: replacements)
+      end
+    end
+
+    # Runs the accuracy test and log results
+    def test_accuracy(subject_uri:, expected_by_position:, pending: false)
+      dt_start = QaServer::TimeService.current_time
+      results = yield if block_given?
+      dt_end = QaServer::TimeService.current_time
+      if results.blank?
+        log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: no results found", expected: expected_by_position,
+            target: subject_uri, request_run_time: (dt_end - dt_start), pending: pending)
+        return
       end
 
-      # CONCRETE Implementation: Run the connection test and log results
-      def run_connection_scenario
-        test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'search') do
-          replacements = scenario.replacements.dup
-          authority.search(scenario.query,
-                           subauth: scenario.subauthority_name,
-                           replacements: replacements)
-        end
+      check_position(results, subject_uri, expected_by_position, total_run_time: (dt_end - dt_start), pending: pending) # TODO: need to get run times from results
+    rescue Exception => e
+      dt_end = QaServer::TimeService.current_time
+      log(status: FAIL, errmsg: "Exception executing search position scenario; cause: #{e.message}",
+          expected: expected_by_position, target: subject_uri, request_run_time: (dt_end - dt_start), pending: pending)
+    end
+
+    def accuracy_scenario?
+      return false if scenario.expected_by_position.blank? || scenario.subject_uri.blank?
+      true
+    end
+
+    def connection_scenario?
+      # There are only two types of tests, so if this isn't an accuracy scenario, it must be a connection scenario.
+      !accuracy_scenario?
+    end
+
+    def check_position(results, subject_uri, expected_by_position, total_run_time:, pending:)
+      actual_position = subject_position(results, subject_uri, total_run_time, pending)
+      return if actual_position.blank?
+
+      if actual_position <= expected_by_position
+        log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri,
+            normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
+      else
+        log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.',
+            expected: expected_by_position, actual: actual_position, target: subject_uri,
+            normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
       end
+    end
 
-      # CONCRETE Implementation: Run the accuracy test and log results
-      def run_accuracy_scenario
-        test_accuracy(subject_uri: scenario.subject_uri, expected_by_position: scenario.expected_by_position, pending: scenario.pending?) do
-          replacements = scenario.replacements.dup
-          authority.search(scenario.query,
-                           subauth: scenario.subauthority_name,
-                           replacements: replacements)
-        end
+    def subject_position(results, subject_uri, total_run_time, pending)
+      0.upto(results.size - 1) do |position|
+        return position + 1 if results[position][:uri] == subject_uri
       end
-
-      # Runs the accuracy test and log results
-      def test_accuracy(subject_uri:, expected_by_position:, pending: false)
-        dt_start = QaServer::TimeService.current_time
-        results = yield if block_given?
-        dt_end = QaServer::TimeService.current_time
-        if results.blank?
-          log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: no results found", expected: expected_by_position,
-              target: subject_uri, request_run_time: (dt_end - dt_start), pending: pending)
-          return
-        end
-
-        check_position(results, subject_uri, expected_by_position, total_run_time: (dt_end - dt_start), pending: pending) # TODO: need to get run times from results
-      rescue Exception => e
-        dt_end = QaServer::TimeService.current_time
-        log(status: FAIL, errmsg: "Exception executing search position scenario; cause: #{e.message}",
-            expected: expected_by_position, target: subject_uri, request_run_time: (dt_end - dt_start), pending: pending)
-      end
-
-      def accuracy_scenario?
-        return false if scenario.expected_by_position.blank? || scenario.subject_uri.blank?
-        true
-      end
-
-      def connection_scenario?
-        # There are only two types of tests, so if this isn't an accuracy scenario, it must be a connection scenario.
-        !accuracy_scenario?
-      end
-
-      def check_position(results, subject_uri, expected_by_position, total_run_time:, pending:)
-        actual_position = subject_position(results, subject_uri, total_run_time, pending)
-        return if actual_position.blank?
-
-        if actual_position <= expected_by_position
-          log(status: PASS, expected: expected_by_position, actual: actual_position, target: subject_uri,
-              normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
-        else
-          log(status: UNKNOWN, errmsg: 'Subject URI not found by the expected position.',
-              expected: expected_by_position, actual: actual_position, target: subject_uri,
-              normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
-        end
-      end
-
-      def subject_position(results, subject_uri, total_run_time, pending)
-        0.upto(results.size - 1) do |position|
-          return position + 1 if results[position][:uri] == subject_uri
-        end
-        log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: subject uri (#{subject_uri}) not found in results",
-            expected: scenario.expected_by_position, target: subject_uri, normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
-        nil
-      end
+      log(status: UNKNOWN, errmsg: "Search position scenario failed; cause: subject uri (#{subject_uri}) not found in results",
+          expected: scenario.expected_by_position, target: subject_uri, normalization_run_time: total_run_time, pending: pending) # TODO: need to get run times from results
+      nil
+    end
   end
 end

--- a/app/validators/qa_server/term_scenario_validator.rb
+++ b/app/validators/qa_server/term_scenario_validator.rb
@@ -16,33 +16,33 @@ module QaServer
       @request_data = scenario.identifier
     end
 
-    private
+  private
 
-      # CONCRETE Implementation: Run a term scenario and log results.
-      def run_connection_scenario
-        test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'term') do
-          authority.find(scenario.identifier,
-                         subauth: scenario.subauthority_name)
-        end
+    # CONCRETE Implementation: Run a term scenario and log results.
+    def run_connection_scenario
+      test_connection(min_expected_size: scenario.min_result_size, scenario_type_name: 'term') do
+        authority.find(scenario.identifier,
+                       subauth: scenario.subauthority_name)
       end
+    end
 
-      # CONCRETE Implementation: Run a term scenario and log results.
-      def run_accuracy_scenario
-        # no accuracy scenarios defined for terms at this time
-      end
+    # CONCRETE Implementation: Run a term scenario and log results.
+    def run_accuracy_scenario
+      # no accuracy scenarios defined for terms at this time
+    end
 
-      def action
-        TERM_ACTION
-      end
+    def action
+      TERM_ACTION
+    end
 
-      def accuracy_scenario?
-        # At this time, all scenarios are connection scenarios for terms.
-        false
-      end
+    def accuracy_scenario?
+      # At this time, all scenarios are connection scenarios for terms.
+      false
+    end
 
-      def connection_scenario?
-        # At this time, all scenarios are connection scenarios for terms.
-        true
-      end
+    def connection_scenario?
+      # At this time, all scenarios are connection scenarios for terms.
+      true
+    end
   end
 end

--- a/lib/generators/qa_server/assets_generator.rb
+++ b/lib/generators/qa_server/assets_generator.rb
@@ -28,9 +28,9 @@ class QaServer::AssetsGenerator < Rails::Generators::Base
     end
   end
 
-  private
+private
 
-    def qa_server_javascript_installed?
-      IO.read("app/assets/javascripts/application.js").include?('qa_server')
-    end
+  def qa_server_javascript_installed?
+    IO.read("app/assets/javascripts/application.js").include?('qa_server')
+  end
 end

--- a/lib/qa_server/configuration.rb
+++ b/lib/qa_server/configuration.rb
@@ -253,23 +253,23 @@ module QaServer
       @monitor_logger ||= Logger.new(ENV['MONITOR_LOG_PATH'] || File.join("log", "monitor.log"))
     end
 
-    private
+  private
 
-      def convert_size_to_bytes(size)
-        return if size.nil?
-        md = size.match(/^(?<num>\d+)\s?(?<unit>\w+)?$/)
-        return md[:num].to_i if md[:unit].nil?
-        md[:num].to_i *
-          case md[:unit].upcase
-          when 'KB'
-            1024
-          when 'MB'
-            1024**2
-          when 'GB'
-            1024**3
-          else
-            1
-          end
-      end
+    def convert_size_to_bytes(size)
+      return if size.nil?
+      md = size.match(/^(?<num>\d+)\s?(?<unit>\w+)?$/)
+      return md[:num].to_i if md[:unit].nil?
+      md[:num].to_i *
+        case md[:unit].upcase
+        when 'KB'
+          1024
+        when 'MB'
+          1024**2
+        when 'GB'
+          1024**3
+        else
+          1
+        end
+    end
   end
 end

--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'better_errors' # provide debugging command line in
   spec.add_development_dependency 'binding_of_caller' # provides deep stack info used by better_errors
-  spec.add_development_dependency 'bixby', '~> 1.0.0' # rubocop styleguide
+  spec.add_development_dependency 'bixby', '~> 3.0.0' # rubocop styleguide
   # spec.add_development_dependency "capybara", '~> 3.29'
   # spec.add_development_dependency 'capybara-maleficent', '~> 0.3.0'
   # spec.add_development_dependency 'chromedriver-helper', '~> 2.1'


### PR DESCRIPTION
The latest rubocop requires private methods to be indented at the same level as public methods.  The private marker is either indented the same our outdented 2 spaces.  QaServer is configured for outdent.

For ease of review, there are two commits:
* all fixes that are not indentation related
* indentation related fixes