### PR TITLE
sync authorities configs and validations with production lookup

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/getty_aat_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/getty_aat_ld4l_cache.json
@@ -2,6 +2,7 @@
   "QA_CONFIG_VERSION": "2.2",
   "service_uri": "http://ld4l.org/ld4l_services/cache",
   "prefixes": {
+    "getty":   "http://vocab.getty.edu/ontology#",
     "vivo":    "http://vivoweb.org/ontology/core#"
   },
   "term": {
@@ -89,6 +90,67 @@
       "label_ldpath": "skos:prefLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
+    "context": {
+      "groups": {
+        "hierarchies": {
+          "group_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.hierarchies",
+          "group_label_default": "Hierarchies"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.alt_label",
+          "property_label_default": "Alternative Label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.scope_note",
+          "property_label_default": "Scope note",
+          "ldpath": "skos:scopeNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.hierarchy",
+          "property_label_default": "Hierarchy",
+          "ldpath": "gvp:broaderPreferredExtended :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        }
+      ]
+    },
     "subauthorities": {
       "Activities":                              "&facet=300264090",
       "Activities__Disciplines":                  "&facet=300054134",
@@ -123,4 +185,3 @@
     }
   }
 }
-

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/getty_tgn_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/getty_tgn_ld4l_cache.json
@@ -3,7 +3,8 @@
   "service_uri": "http://ld4l.org/ld4l_services/cache",
   "prefixes": {
     "getty":   "http://vocab.getty.edu/ontology#",
-    "vivo":    "http://vivoweb.org/ontology/core#"
+    "vivo":    "http://vivoweb.org/ontology/core#",
+    "xl":      "http://www.w3.org/2008/05/skos-xl#"
   },
   "term": {
     "url": {
@@ -85,11 +86,34 @@
     "context": {
       "properties": [
         {
-          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.parent_string",
-          "property_label_default": "Parent",
-          "ldpath": "getty:parentString :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "^foaf:focus/xl:prefLabel/xl:literalForm :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.variant_label",
+          "property_label_default": "Variant Label",
+          "ldpath": "^foaf:focus/xl:altLabel/xl:literalForm :: xsd:string",
           "selectable": false,
           "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.place_type",
+          "property_label_default": "Place type",
+          "ldpath": "^foaf:focus/gvp:placeTypePreferred :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "^foaf:focus/gvp:broaderPreferred/xl:altLabel/xl:literalForm :: xsd:string",
+          "selectable": false,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
         }
       ]
     }

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locvocabs_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locvocabs_ld4l_cache.json
@@ -1,0 +1,117 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.info-science.uiowa.edu:8081/ld4l_services/loc_vocab_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "label_ldpath":    "madsrdf:authoritativeLabel ::xsd:string",
+      "sort_ldpath":     "vivo:rank ::xsd:string"
+    },
+    "subauthorities": {
+      "carriers":            "carriers",
+      "content_types":       "contentTypes",
+      "description_conventions": "descriptionConventions",
+      "frequencies":         "frequencies",
+      "issuance":            "issuance",
+      "marcauthen":          "marcauthen",
+      "maspect":             "maspect",
+      "maudience":           "maudience",
+      "mbroadstd":           "mbroadstd",
+      "mcapturestorage":     "mcapturestorage",
+      "mcolor":              "mcolor",
+      "media_types":         "mediaTypes",
+      "mencformat":          "mencformat",
+      "menclvl":             "menclvl",
+      "mfiletype":           "mfiletype",
+      "mfont":               "mfont",
+      "mgeneration":         "mgeneration",
+      "mgovtpubtype":        "mgovtpubtype",
+      "mgroove":             "mgroove",
+      "millus":              "millus",
+      "mlayout":             "mlayout",
+      "mmaterial":           "mmaterial",
+      "mmusicformat":        "mmusicformat",
+      "mmusnotation":        "mmusnotation",
+      "mplayback":           "mplayback",
+      "mplayspeed":          "mplayspeed",
+      "mpolarity":           "mpolarity",
+      "mpresformat":         "mpresformat",
+      "mproduction":         "mproduction",
+      "mprojection":         "mprojection",
+      "mpunctuation_conventions": "mpunctuationConventions",
+      "mrecmedium":          "mrecmedium",
+      "mrectype":            "mrectype",
+      "mreductionratio":     "mreductionratio",
+      "mregencoding":        "mregencoding",
+      "mrelief":             "mrelief",
+      "mscale":              "mscale",
+      "mscript":             "mscript",
+      "msoundcontent":       "msoundcontent",
+      "mspecplayback":       "mspecplayback",
+      "mstatus":             "mstatus",
+      "msupplcont":          "msupplcont",
+      "mtactile":            "mtactile",
+      "mtapeconfig":         "mtapeconfig",
+      "mtechnique":          "mtechnique",
+      "mvidformat":          "mvidformat",
+      "relators":            "relators",
+      "resource_components": "resourceComponents"
+    }
+  }
+}

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
@@ -42,6 +42,7 @@ search:
   -
     query: University of Chicago Library
     subauth: organization
+    result_size: 100
     subject_uri: "http://vocab.getty.edu/ulan/500304715"
     postion: 5
     replacements:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
@@ -1,0 +1,184 @@
+# Supported subauthorities:
+#   carriers
+#   content_types
+---
+authority:
+  service: ld4l_cache
+  context: false
+search:
+  -
+    query: audio
+    subauth: carriers
+  -
+    query: image
+    subauth: content_types
+  -
+    query: rare books
+    subauth: description_conventions
+  -
+    query: daily
+    subauth: frequencies
+    result_size: 120
+  -
+    query: serial
+    subauth: issuance
+    result_size: 110
+  -
+    query: ISSN
+    subauth: marcauthen
+  -
+    query: full
+    subauth: maspect
+    result_size: 110
+  -
+    query: general
+    subauth: maudience
+    result_size: 110
+  -
+    query: pal
+    subauth: mbroadstd
+    result_size: 110
+  -
+    query: electrical
+    subauth: mcapturestorage
+  -
+    query: gray
+    subauth: mcolor
+    result_size: 110
+  -
+    query: video
+    subauth: media_types
+    result_size: 110
+  -
+    query: dvd
+    subauth: mencformat
+  -
+    query: core
+    subauth: menclvl
+    result_size: 100
+  -
+    query: data
+    subauth: mfiletype
+    result_size: 110
+  -
+    query: print
+    subauth: mfont
+  -
+    query: original
+    subauth: mgeneration
+  -
+    query: state
+    subauth: mgovtpubtype
+    result_size: 110
+  -
+    query: fine
+    subauth: mgroove
+    result_size: 110
+  -
+    query: music
+    subauth: millus
+    result_size: 110
+  -
+    query: paragraph
+    subauth: mlayout
+    result_size: 110
+  -
+    query: vinyl
+    subauth: mmaterial
+    result_size: 110
+  -
+    query: score
+    subauth: mmusicformat
+  -
+    query: tablature
+    subauth: mmusnotation
+    result_size: 100
+  -
+    query: mixed
+    subauth: mplayback
+    result_size: 100
+  -
+    query: 160
+    subauth: mplayspeed
+    result_size: 100
+  -
+    query: negative
+    subauth: mpolarity
+    result_size: 100
+  -
+    query: multiscreen
+    subauth: mpresformat
+    result_size: 100
+  -
+    query: etching
+    subauth: mproduction
+    result_size: 100
+  -
+    query: miller
+    subauth: mprojection
+  -
+    query: isbd
+    subauth: mpunctuation_conventions
+    result_size: 100
+  -
+    query: optical
+    subauth: mrecmedium
+    result_size: 100
+  -
+    query: analog
+    subauth: mrectype
+    result_size: 100
+  -
+    query: high
+    subauth: mreductionratio
+  -
+    query: region 8
+    subauth: mregencoding
+    result_size: 100
+  -
+    query: land
+    subauth: mrelief
+    result_size: 100
+  -
+    query: scale
+    subauth: mscale
+    result_size: 100
+  -
+    query: chinese
+    subauth: mscript
+    result_size: 100
+  -
+    query: silent
+    subauth: msoundcontent
+    result_size: 100
+  -
+    query: audio
+    subauth: mspecplayback
+  -
+    query: invalid
+    subauth: mstatus
+    result_size: 100
+  -
+    query: index
+    subauth: msupplcont
+  -
+    query: braille
+    subauth: mtactile
+  -
+    query: half
+    subauth: mtapeconfig
+    result_size: 100
+  -
+    query: action
+    subauth: mtechnique
+  -
+    query: laser
+    subauth: mvidformat
+    result_size: 100
+  -
+    query: actor
+    subauth: relators
+  -
+    query: sound
+    subauth: resource_components
+    result_size: 100

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
@@ -46,6 +46,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: Email
     subauth: subject
     subject_uri: "http://id.nlm.nih.gov/mesh/D034742"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -68,6 +68,7 @@ search:
   -
     query: Sjælland
     subauth: place
+    result_size: 190
     subject_uri: "http://id.worldcat.org/fast/1243881"
     postion: 5
     replacements:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
@@ -294,7 +294,7 @@ search:
     subject_uri: "http://rdaregistry.info/termList/MusNotation/1009"
     replacements:
       maxRecords: '20'
-   -
+  -
     query: jigsaw puzzle
     subauth: carrier_extent_unit
     position: 3
@@ -319,7 +319,7 @@ search:
     query: polychrome
     subauth: colour_content
     position: 3
-    subject_uri: "http://rdaregistry.info/termList/RDAColourContent/1003"
+    subject_uri: "http://rdaregistry.info/termList/RDACartoDT/1003"
     replacements:
       maxRecords: '20'
   -
@@ -560,6 +560,3 @@ search:
     subject_uri: "http://rdaregistry.info/termList/videoFormat/1007"
     replacements:
       maxRecords: '10'
-term:
-  -
-    identifier: 'http://rdaregistry.info/termList/ModeIssue/1002'


### PR DESCRIPTION
* add extended context for
   * getty_aat_ld4l_cache
   * getty_tgn_ld4l_cache
* add authorities
   * locvocabs_ld4l_cache
* adjust validations
   * fix a few syntax errors
   * adjust result_size for validations that return less than 200 chars when passing
   * remove term connection tests when fetch term is not supported