### PR TITLE
add pending to failing validation tests

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo2_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo2_ld4l_cache.json
@@ -1,0 +1,248 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath":    "rdfs:label ::xsd:string",
+      "altlabel_ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath": "rdfs:label ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
+        }
+      },
+      "properties": [
+        {
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdfs:label :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Descriptor",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Birth date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+          "ldpath": "madsrdf:birthDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "optional": true,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Death date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_date",
+          "ldpath": "madsrdf:deathDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Location",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.location",
+          "ldpath": "(madsrdf:associatedLocale/skos:prefLabel) | (madsrdf:associatedLocale/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["organization", "family"]
+        },
+        {
+          "property_label_default": "Affiliation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) | (madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Field of activity",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:fieldOfActivity/skos:prefLabel) | (madsrdf:fieldOfActivity/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Occupation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.occupation",
+          "ldpath": "(madsrdf:occupation/skos:prefLabel) | (madsrdf:occupation/rdfs:label) | (madsrdf:occupation/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Birth place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_place",
+          "ldpath": "(madsrdf:birthPlace/skos:prefLabel) | (madsrdf:birthPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Death place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_place",
+          "ldpath": "(madsrdf:deathPlace/skos:prefLabel) | (madsrdf:deathPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "property_label_default": "VIAF match",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.viaf_match",
+          "ldpath": "^madsrdf:identifiesRWO/skos:exactMatch :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Variant label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:editorialNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Authority URI",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.authority_uri",
+          "ldpath": "^madsrdf:identifiesRWO :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "person":         "Person",
+      "organization":   "Organization",
+      "family":         "Family"
+    }
+  }
+}

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo3_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo3_ld4l_cache.json
@@ -1,0 +1,248 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath":    "rdfs:label ::xsd:string",
+      "altlabel_ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath": "rdfs:label ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
+        }
+      },
+      "properties": [
+        {
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdfs:label :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Descriptor",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Birth date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+          "ldpath": "madsrdf:birthDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "optional": true,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Death date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_date",
+          "ldpath": "madsrdf:deathDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Location",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.location",
+          "ldpath": "(madsrdf:associatedLocale/skos:prefLabel) | (madsrdf:associatedLocale/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["organization", "family"]
+        },
+        {
+          "property_label_default": "Affiliation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) | (madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Field of activity",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:fieldOfActivity/skos:prefLabel) | (madsrdf:fieldOfActivity/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Occupation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.occupation",
+          "ldpath": "(madsrdf:occupation/skos:prefLabel) | (madsrdf:occupation/rdfs:label) | (madsrdf:occupation/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Birth place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_place",
+          "ldpath": "(madsrdf:birthPlace/skos:prefLabel) | (madsrdf:birthPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Death place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_place",
+          "ldpath": "(madsrdf:deathPlace/skos:prefLabel) | (madsrdf:deathPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "property_label_default": "VIAF match",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.viaf_match",
+          "ldpath": "^madsrdf:identifiesRWO/skos:exactMatch :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Variant label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:editorialNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Authority URI",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.authority_uri",
+          "ldpath": "^madsrdf:identifiesRWO :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "person":         "Person",
+      "organization":   "Organization",
+      "family":         "Family"
+    }
+  }
+}

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/agrovoc_direct_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/agrovoc_direct_validation.yml
@@ -11,6 +11,7 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: extrakce rozpouštědlem
     position: 5
     subject_uri: "http://aims.fao.org/aos/agrovoc/c_28368"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
@@ -39,6 +39,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: Jacob Winter
     subauth: person
     position: 2
@@ -60,6 +61,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: Plantin
     subauth: imprint
     position: 1

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
@@ -24,12 +24,14 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Volleyb
     position: 5
     subject_uri: "http://dbpedia.org/resource/Volleyball"
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: volleyb
     position: 5
     subject_uri: "http://dbpedia.org/resource/Volleyball"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_direct_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_direct_validation.yml
@@ -11,21 +11,32 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: France
     subject_uri: 'http://sws.geonames.org/261707/'
     position: 10
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: New York
     subject_uri: "http://sws.geonames.org/5128581/"
     position: 3
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: Chicago
     subject_uri: 'http://sws.geonames.org/4887398/'
-    postion: 10
+    position: 10
+    replacements:
+      maxRecords: '15'
+  -
+    pending: true
+    query: Ithaca Island
+    subauth: terrain
+    subject_uri: "http://sws.geonames.org/261707/"
+    position: 10
     replacements:
       maxRecords: '15'
 term:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
@@ -62,12 +62,14 @@ search:
   #    vegetation
   #    all
   -
+    pending: true
     query: New York
     subject_uri: "http://sws.geonames.org/5128581/"
     position: 3
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: France
     subauth: area
     subject_uri: "http://sws.geonames.org/3017382"
@@ -75,17 +77,18 @@ search:
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: Chicago
     subauth: place
     subject_uri: "http://sws.geonames.org/4887398/"
-    postion: 10
+    position: 10
     replacements:
       maxRecords: '15'
   -
     query: Ithaca Island
     subauth: terrain
     subject_uri: "http://sws.geonames.org/261707/"
-    postion: 10
+    position: 10
     replacements:
       maxRecords: '15'
 term:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_aat_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_aat_ld4l_cache_validation.yml
@@ -222,6 +222,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: alter egos
     subauth: Agents__People
     position: 5
@@ -236,6 +237,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: palindrome
     subauth: Associated_Concepts__Associated_Concepts
     position: 5
@@ -271,6 +273,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: lloy lloy
     subauth: Objects
     position: 5

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_tgn_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_tgn_ld4l_cache_validation.yml
@@ -12,24 +12,28 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Gouverneur
     position: 3
     subject_uri: "http://vocab.getty.edu/tgn/2069433-place"
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Boulder, CO
     position: 9
     subject_uri: "http://vocab.getty.edu/tgn/2000198-place"
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Paris, France
     position: 30
     subject_uri: "http://vocab.getty.edu/tgn/7008038-place"
     replacements:
       maxRecords: '100'
   -
+    pending: true
     query: Nile River
     position: 3
     subject_uri: "http://vocab.getty.edu/tgn/1127805-place"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
@@ -44,7 +44,7 @@ search:
     subauth: organization
     result_size: 100
     subject_uri: "http://vocab.getty.edu/ulan/500304715"
-    postion: 5
+    position: 5
     replacements:
       maxRecords: '10'
 term:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
@@ -19,18 +19,21 @@ search:
     replacements:
       maxRecords: '5'
   -
+    pending: true
     query: Biologist
     position: 3
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060613"
     replacements:
       maxRecords: '5'
   -
+    pending: true
     query: social worker
     position: 1
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Social Worker
     position: 1
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
@@ -55,6 +58,7 @@ search:
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: African Americans
     position: 5
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060859"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
@@ -30,6 +30,7 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: maps
     position: 3
     subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026387"
@@ -115,6 +116,7 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: Cookery
     subauth: deprecated
     position: 5

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -10,12 +10,6 @@ search:
   # Connection tests
   #------------------
   -
-    query: Boston Mass
-    position: 3
-    subject_uri: "http://id.loc.gov/authorities/names/n79045553"
-    replacements:
-      maxRecords: '10'
-  -
     query: Cayuga
   -
     query: Cayuga
@@ -27,13 +21,14 @@ search:
   #  Accuracy tests
   #------------------
   -
-    query: Camden NJ
-    position: 8
-    subauth: geographic
-    subject_uri: "http://id.loc.gov/authorities/names/n81139356"
+    pending: true
+    query: Boston Mass
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/names/n79045553"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
+    pending: true
     query: Boston Mass
     position: 5
     subauth: geographic
@@ -41,6 +36,15 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
+    query: Camden NJ
+    position: 8
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n81139356"
+    replacements:
+      maxRecords: '20'
+  -
+    pending: true
     query: Madrid, Spain
     position: 5
     subauth: geographic
@@ -48,6 +52,7 @@ search:
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: Chicago, Ill
     position: 5
     subauth: geographic
@@ -55,6 +60,7 @@ search:
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: seattle
     position: 5
     subauth: geographic
@@ -62,6 +68,7 @@ search:
     replacements:
       maxRecords: '15'
   -
+    pending: true
     query: seattle (wash.)
     position: 5
     subauth: geographic

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -22,7 +22,7 @@ search:
     query: 'twain'
     subauth: family
   #------------------
-  #  Accuracy tests
+  #  Accuracy tests - Part 1 (1-9)
   #------------------
   -
     query: Twain, Mark, 1835-1910
@@ -32,6 +32,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Camden, William
     subauth: person
     position: 10
@@ -60,6 +61,7 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: Tanaka, Shozo
     subauth: person
     position: 5
@@ -74,6 +76,7 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: Endalageta Kabada
     subauth: person
     position: 5
@@ -87,125 +90,6 @@ search:
     subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
     replacements:
       maxRecords: '20'
-  -
-    query: Tolstoy, Leo
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: tolstoi, lev
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Tolstoĭ, Lev
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Толстой, Лев
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Толстой, Лев, граф, 1828-1910
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: טאלסטאי, ליעװ
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: レオ.トルストイ
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: لئون تولستوى
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: 托爾斯泰, 列夫
-    subauth: person
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
-    replacements:
-      maxRecords: '20'
-  -
-    query: ACLU
-    subauth: organization
-    position: 20
-    subject_uri: "http://id.loc.gov/rwo/agents/n79079580"
-    replacements:
-      maxRecords: '30'
-  -
-    query: University of Pennsylvania
-    subauth: organization
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
-    replacements:
-      maxRecords: '20'
-  -
-    query: university of pennsylvania
-    subauth: organization
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Planned Parenthood Federation of America
-    subauth: organization
-    position: 10
-    subject_uri: "http://id.loc.gov/rwo/agents/n50075375"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Genkai Shosetsu Kenkyukai
-    subauth: organization
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Genkai Shōsetsu Kenkyūkai
-    subauth: organization
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
-    replacements:
-      maxRecords: '20'
-  -
-    query: 限界小說研究会
-    subauth: organization
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
-    replacements:
-      maxRecords: '20'
-  -
-    query: Waterman Family
-    subauth: family
-    position: 5
-    subject_uri: "http://id.loc.gov/rwo/agents/n2012043300"
-    replacements:
-      maxRecords: '10'
 term:
   -
     identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
@@ -12,6 +12,7 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Guitar music (Heavy metal) # example of LCSH with parentheses
     position: 10
     subject_uri: "http://id.loc.gov/authorities/subjects/sh85059850"
@@ -30,12 +31,7 @@ search:
     replacements:
       maxRecords: '20'
   -
-    query: History
-    position: 5
-    subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
-    replacements:
-      maxRecords: '20'
-  -
+    pending: true
     query: History
     position: 5
     subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
@@ -26,12 +26,14 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Malignant Hyperthermia
     subject_uri: "http://id.nlm.nih.gov/mesh/D008305"
     position: 3
     replacements:
       maxRecords: '5'
   -
+    pending: true
     query: Heart Attack
     subauth: subject
     subject_uri: "http://id.nlm.nih.gov/mesh/D009203"
@@ -50,7 +52,7 @@ search:
     query: Email
     subauth: subject
     subject_uri: "http://id.nlm.nih.gov/mesh/D034742"
-    postion: 5
+    position: 5
     replacements:
       maxRecords: '10'
 term:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/nalt_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/nalt_ld4l_cache_validation.yml
@@ -39,7 +39,7 @@ search:
   -
     query: recorte de los cascos
     subject_uri: "http://lod.nal.usda.gov/nalt/9231"
-    postion: 3
+    position: 3
     replacements:
       maxRecords: '5'
 term:

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclc_fast_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclc_fast_validation.yml
@@ -61,6 +61,64 @@ search:
     subauth: alt_lc
     replacements:
       maximumRecords: '4'
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Tralee & Dingle Railway
+    subject_uri: "http://id.worldcat.org/fast/1733583"
+    position: 3
+    replacements:
+      maxRecords: '5'
+  -
+    pending: true
+    query: Sleep-overs
+    subauth: concept
+    subject_uri: "http://id.worldcat.org/fast/1120873"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    pending: true
+    query: People's International Tribunal on the Rights of Indigenous Hawaiians
+    subauth: event
+    subject_uri: "http://id.worldcat.org/fast/1410299"
+    position: 3
+    replacements:
+      maxRecords: '8'
+  -
+    pending: true
+    query: University of Chicago Library
+    subauth: organization
+    subject_uri: "http://id.worldcat.org/fast/539173"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    pending: true
+    query: Taylor, Charles Hollis
+    subauth: person
+    subject_uri: "http://id.worldcat.org/fast/1616125"
+    position: 15
+    replacements:
+      maxRecords: '20'
+  -
+    pending: true
+    query: Sjælland
+    subauth: place
+    result_size: 190
+    subject_uri: "http://id.worldcat.org/fast/1243881"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    pending: true
+    query: Scream
+    subauth: work
+    subject_uri: "http://id.worldcat.org/fast/1358031"
+    position: 5
+    replacements:
+      maxRecords: '10'
 term:
   -
     identifier: '1914919'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
@@ -61,6 +61,63 @@ search:
     subauth: alt_lc
     replacements:
       maxRecords: '4'
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Tralee & Dingle Railway
+    subject_uri: "http://id.worldcat.org/fast/1733583"
+    position: 3
+    replacements:
+      maxRecords: '5'
+  -
+    pending: true
+    query: Sleep-overs
+    subauth: concept
+    subject_uri: "http://id.worldcat.org/fast/1120873"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    pending: true
+    query: People's International Tribunal on the Rights of Indigenous Hawaiians
+    subauth: event
+    subject_uri: "http://id.worldcat.org/fast/1410299"
+    position: 3
+    replacements:
+      maxRecords: '8'
+  -
+    pending: true
+    query: University of Chicago Library
+    subauth: organization
+    subject_uri: "http://id.worldcat.org/fast/539173"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    query: Taylor, Charles Hollis
+    subauth: person
+    subject_uri: "http://id.worldcat.org/fast/1616125"
+    position: 15
+    replacements:
+      maxRecords: '20'
+  -
+    pending: true
+    query: Sjælland
+    subauth: place
+    result_size: 190
+    subject_uri: "http://id.worldcat.org/fast/1243881"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
+    pending: true
+    query: Scream
+    subauth: work
+    subject_uri: "http://id.worldcat.org/fast/1358031"
+    position: 5
+    replacements:
+      maxRecords: '10'
 term:
   -
     identifier: '1914919'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -32,6 +32,7 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Tralee & Dingle Railway
     subject_uri: "http://id.worldcat.org/fast/1733583"
     position: 3
@@ -55,7 +56,7 @@ search:
     query: University of Chicago Library
     subauth: organization
     subject_uri: "http://id.worldcat.org/fast/539173"
-    postion: 5
+    position: 5
     replacements:
       maxRecords: '10'
   -
@@ -70,14 +71,14 @@ search:
     subauth: place
     result_size: 190
     subject_uri: "http://id.worldcat.org/fast/1243881"
-    postion: 5
+    position: 5
     replacements:
       maxRecords: '10'
   -
     query: Scream
     subauth: work
     subject_uri: "http://id.worldcat.org/fast/1358031"
-    postion: 5
+    position: 5
     replacements:
       maxRecords: '10'
 

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
@@ -316,10 +316,11 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: polychrome
     subauth: colour_content
     position: 3
-    subject_uri: "http://rdaregistry.info/termList/RDACartoDT/1003"
+    subject_uri: "http://rdaregistry.info/termList/RDAColourContent/1003"
     replacements:
       maxRecords: '20'
   -
@@ -456,6 +457,7 @@ search:
     replacements:
       maxRecords: '20'
   -
+    pending: true
     query: unknown
     subauth: gender
     position: 3
@@ -554,6 +556,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Hi 8
     subauth: video_format
     position: 3


### PR DESCRIPTION
Also...
* fixes typo in `position` and removes duplicate test
* splits LOC_RWO into 3 sets of tests of about 9 tests each
* changes subject_uri of RDA_REGISTRY/colour_content q=polychrome, but may be an incorrect change.  See notes below...

Not sure of the subject URI for RDA_REGISTRY polychrome search in subauth colour_content.  I'm seeing different URIs in LD4P/qa_server and cult-it/qa_server.  Both versions fail.

```
    subject_uri: "http://rdaregistry.info/termList/RDAColourContent/1003"	
    subject_uri: "http://rdaregistry.info/termList/RDACartoDT/1003"
```