### PR TITLE
Fixed URI Camden, N.J.

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -40,7 +40,7 @@ search:
     query: Camden NJ
     position: 8
     subauth: geographic
-    subject_uri: "http://id.loc.gov/authorities/names/n81139356"
+    subject_uri: "http://id.loc.gov/authorities/names/n80010449"
     replacements:
       maxRecords: '20'
   -


### PR DESCRIPTION
http://id.loc.gov/authorities/names/n80010449.