### PR TITLE
sync authority configs and validations

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
@@ -72,7 +72,7 @@ search:
     pending: true
     query: France
     subauth: area
-    subject_uri: "http://sws.geonames.org/3017382"
+    subject_uri: "http://sws.geonames.org/3017382/"
     position: 10
     replacements:
       maxRecords: '15'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
@@ -20,12 +20,14 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Gonzalez-Torres, Felix
     subject_uri: "http://vocab.getty.edu/ulan/500114715-agent"
     position: 5
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Gouverneur
     subauth: person
     subject_uri: "http://vocab.getty.edu/ulan/500225342-agent"
@@ -33,6 +35,7 @@ search:
     replacements:
       maxRecords: '10'
   -
+    pending: true
     query: Octavio Medellin
     subauth: person
     subject_uri: "http://vocab.getty.edu/ulan/500333005-agent"
@@ -40,6 +43,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: University of Chicago Library
     subauth: organization
     result_size: 100


### PR DESCRIPTION
Remove pending from all geonames validations.

Add pending to all getty_ulan validations.