### PR TITLE
Deleting Cookery Test

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
@@ -115,14 +115,7 @@ search:
     subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026080"
     replacements:
       maxRecords: '20'
-  -
-    pending: true
-    query: Cookery
-    subauth: deprecated
-    position: 5
-    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026169"
-    replacements:
-      maxRecords: '10'
+ 
 term:
   -
     identifier: "http://id.loc.gov/authorities/genreForms/gf2011026141"


### PR DESCRIPTION
The test doesn't pass because the deprecated entity is in a different data set.