### PR TITLE
update authorities

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo2_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo2_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo3_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo3_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_direct.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_direct.json
@@ -70,8 +70,11 @@
     },
     "subauthorities": {
       "topic":          "oclc.topic",
+      "concept":        "oclc.topic",
       "geocoordinates": "oclc.geographic",
       "geographic":     "oclc.geographic",
+      "place":          "oclc.geographic",
+      "event":          "oclc.eventName",
       "event_name":     "oclc.eventName",
       "meeting":        "oclc.meeting",
       "person":         "oclc.personalName",
@@ -79,6 +82,7 @@
       "organization":   "oclc.corporateName",
       "corporate_name": "oclc.corporateName",
       "uniform_title":  "oclc.uniformTitle",
+      "work":           "oclc.uniformTitle",
       "period":         "oclc.period",
       "form":           "oclc.form",
       "alt_lc":         "oclc.altlc"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_ld4l_cache.json
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/oclcfast_ld4l_cache.json
@@ -91,6 +91,7 @@
     "subauthorities": {
       "concept":        "Concept",
       "event":          "Event",
+      "meeting":        "Meeting",
       "person":         "Person",
       "organization":   "Organization",
       "place":          "Place",

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
@@ -64,10 +64,10 @@ search:
   -
     query: Plantin
     subauth: imprint
-    position: 1
+    position: 18
     subject_uri: "http://thesaurus.cerl.org/record/cni00007649"
     replacements:
-      maxRecords: '8'
+      maxRecords: '30'
 term:
   -
     identifier: "http://thesaurus.cerl.org/record/cnp00895966"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/cerl_ld4l_cache_validation.yml
@@ -25,6 +25,7 @@ search:
   #  Accuracy tests
   #------------------
   -
+    pending: true
     query: Johannes Philippus de Lignamine
     subauth: person
     position: 4
@@ -32,6 +33,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: Johannes Philippus de Lignamine
     subauth: person
     position: 4
@@ -39,7 +41,6 @@ search:
     replacements:
       maxRecords: '8'
   -
-    pending: true
     query: Jacob Winter
     subauth: person
     position: 3
@@ -61,7 +62,6 @@ search:
     replacements:
       maxRecords: '8'
   -
-    pending: true
     query: Plantin
     subauth: imprint
     position: 1

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
@@ -62,14 +62,12 @@ search:
   #    vegetation
   #    all
   -
-    pending: true
     query: New York City
     subject_uri: "http://sws.geonames.org/5128581/"
     position: 3
     replacements:
       maxRecords: '8'
   -
-    pending: true
     query: France
     subauth: area
     subject_uri: "http://sws.geonames.org/3017382/"
@@ -77,7 +75,6 @@ search:
     replacements:
       maxRecords: '15'
   -
-    pending: true
     query: Chicago
     subauth: place
     subject_uri: "http://sws.geonames.org/4887398/"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_aat_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_aat_ld4l_cache_validation.yml
@@ -222,7 +222,6 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: alter egos
     subauth: Agents__People
     position: 5
@@ -237,7 +236,6 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: palindrome
     subauth: Associated_Concepts__Associated_Concepts
     position: 5
@@ -273,7 +271,6 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: lloy lloy
     subauth: Objects
     position: 5

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_tgn_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_tgn_ld4l_cache_validation.yml
@@ -12,28 +12,24 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Gouverneur
     position: 3
     subject_uri: "http://vocab.getty.edu/tgn/2069433-place"
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Boulder, CO
-    position: 9
+    position: 3
     subject_uri: "http://vocab.getty.edu/tgn/2000198-place"
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Paris, France
-    position: 30
+    position: 10
     subject_uri: "http://vocab.getty.edu/tgn/7008038-place"
     replacements:
-      maxRecords: '100'
+      maxRecords: '20'
   -
-    pending: true
     query: Nile River
     position: 3
     subject_uri: "http://vocab.getty.edu/tgn/1127805-place"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
@@ -20,14 +20,12 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Gonzalez-Torres, Felix
     subject_uri: "http://vocab.getty.edu/ulan/500114715-agent"
     position: 5
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Gouverneur
     subauth: person
     subject_uri: "http://vocab.getty.edu/ulan/500225342-agent"
@@ -35,7 +33,6 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Octavio Medellin
     subauth: person
     subject_uri: "http://vocab.getty.edu/ulan/500333005-agent"
@@ -43,7 +40,6 @@ search:
     replacements:
       maxRecords: '8'
   -
-    pending: true
     query: University of Chicago Library
     subauth: organization
     result_size: 100

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
@@ -19,21 +19,18 @@ search:
     replacements:
       maxRecords: '5'
   -
-    pending: true
     query: Biologist
     position: 3
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060613"
     replacements:
       maxRecords: '5'
   -
-    pending: true
     query: social worker
     position: 1
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Social Worker
     position: 1
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
@@ -58,7 +55,6 @@ search:
     replacements:
       maxRecords: '15'
   -
-    pending: true
     query: African Americans
     position: 5
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060859"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locgenres_ld4l_cache_validation.yml
@@ -30,7 +30,6 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: maps
     position: 3
     subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026387"
@@ -115,7 +114,6 @@ search:
     subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026080"
     replacements:
       maxRecords: '20'
- 
 term:
   -
     identifier: "http://id.loc.gov/authorities/genreForms/gf2011026141"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -21,14 +21,12 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Boston Mass
     position: 3
     subject_uri: "http://id.loc.gov/authorities/names/n79045553"
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Boston Mass
     position: 5
     subauth: geographic
@@ -44,7 +42,6 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: Madrid, Spain
     position: 5
     subauth: geographic
@@ -52,7 +49,6 @@ search:
     replacements:
       maxRecords: '15'
   -
-    pending: true
     query: Chicago, Ill
     position: 5
     subauth: geographic
@@ -60,7 +56,6 @@ search:
     replacements:
       maxRecords: '15'
   -
-    pending: true
     query: seattle
     position: 5
     subauth: geographic
@@ -68,7 +63,6 @@ search:
     replacements:
       maxRecords: '15'
   -
-    pending: true
     query: seattle (wash.)
     position: 5
     subauth: geographic

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo2_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo2_ld4l_cache_validation.yml
@@ -1,0 +1,78 @@
+# Supported subauthorities:
+#   person
+#   organization
+#   family
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  #  Accuracy tests - part 2 (10-18)
+  #------------------
+  -
+    query: Tolstoy, Leo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: tolstoi, lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tolstoĭ, Lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев, граф, 1828-1910
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: טאלסטאי, ליעװ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: レオ.トルストイ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: لئون تولستوى
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 托爾斯泰, 列夫
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+term:
+  -
+    identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo3_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo3_ld4l_cache_validation.yml
@@ -1,0 +1,73 @@
+# Supported subauthorities:
+#   person
+#   organization
+#   family
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  #  Accuracy tests - part 3 (19-26)
+  #------------------
+  -
+    pending: true
+    query: ACLU
+    subauth: organization
+    position: 20
+    subject_uri: "http://id.loc.gov/rwo/agents/n79079580"
+    replacements:
+      maxRecords: '30'
+  -
+    query: University of Pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
+    query: university of pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Planned Parenthood Federation of America
+    subauth: organization
+    position: 10
+    subject_uri: "http://id.loc.gov/rwo/agents/n50075375"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shosetsu Kenkyukai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shōsetsu Kenkyūkai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 限界小說研究会
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Waterman Family
+    subauth: family
+    result_size: 110
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2012043300"
+    replacements:
+      maxRecords: '10'
+term:
+  -
+    identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -32,49 +32,47 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Camden, William
     subauth: person
-    position: 10
+    position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n50031528"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
     query: King Stephen 1947
     subauth: person
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n79063767"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
     query: Tweedy, Jeff
     subauth: person
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/no98126226"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
     query: Tanaka, Shōzō
     subauth: person
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
-    pending: true
     query: Tanaka, Shozo
     subauth: person
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
     query: 田中正造
     subauth: person
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
   -
     # The ʼ diacritic in ʼEndālagétā Kabada can't simply be removed; it would change the letter in the search.
     pending: true
@@ -90,7 +88,7 @@ search:
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
 term:
   -
     identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
@@ -12,7 +12,6 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Guitar music (Heavy metal) # example of LCSH with parentheses
     position: 10
     subject_uri: "http://id.loc.gov/authorities/subjects/sh85059850"
@@ -31,12 +30,11 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: History
     position: 5
     subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
 term:
   -
     identifier: 'http://id.loc.gov/authorities/subjects/sh2003008312'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
@@ -6,6 +6,9 @@ authority:
   service: ld4l_cache
   context: false
 search:
+  #------------------
+  # Connection tests
+  #------------------
   -
     query: audio
     subauth: carriers
@@ -182,3 +185,246 @@ search:
     query: sound
     subauth: resource_components
     result_size: 100
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: audio
+    subauth: carriers
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/carriers/sq"
+  -
+    query: image
+    subauth: content_types
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/contentTypes/sti"
+  -
+    query: rare books
+    subauth: description_conventions
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/descriptionConventions/bdrb"
+  -
+    query: daily
+    subauth: frequencies
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/frequencies/dyl"
+  -
+    query: serial
+    subauth: issuance
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/issuance/serl"
+  -
+    query: ISSN
+    subauth: marcauthen
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/marcauthen/isdsc"
+  -
+    query: full
+    subauth: maspect
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/maspect/full"
+  -
+    query: general
+    subauth: maudience
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/maudience/gen"
+  -
+    query: pal
+    subauth: mbroadstd
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mbroadstd/pal"
+  -
+    query: electrical
+    subauth: mcapturestorage
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mcapturestorage/dist"
+  -
+    query: gray
+    subauth: mcolor
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mcolor/gry"
+  -
+    query: video
+    subauth: media_types
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mediaTypes/v"
+  -
+    query: dvd
+    subauth: mencformat
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mencformat/dvdv"
+  -
+    query: core
+    subauth: menclvl
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/menclvl/4"
+  -
+    query: data
+    subauth: mfiletype
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mfiletype/data"
+  -
+    query: print
+    subauth: mfont
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mfont/lp"
+  -
+    query: original
+    subauth: mgeneration
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mgeneration/originalneg"
+  -
+    query: state
+    subauth: mgovtpubtype
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mgovtpubtype/s"
+  -
+    query: fine
+    subauth: mgroove
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mgroove/finepitch"
+  -
+    query: music
+    subauth: millus
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/millus/mus"
+  -
+    query: paragraph
+    subauth: mlayout
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mlayout/para"
+  -
+    query: vinyl
+    subauth: mmaterial
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mmaterial/vny"
+  -
+    query: score
+    subauth: mmusicformat
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mmusicformat/pianoscore"
+  -
+    query: tablature
+    subauth: mmusnotation
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mmusnotation/tabla"
+  -
+    query: mixed
+    subauth: mplayback
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mplayback/mix"
+  -
+    query: 160
+    subauth: mplayspeed
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mplayspeed/i"
+  -
+    query: negative
+    subauth: mpolarity
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mpolarity/neg"
+  -
+    query: multiscreen
+    subauth: mpresformat
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mpresformat/mscreen"
+  -
+    query: etching
+    subauth: mproduction
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mproduction/etch"
+  -
+    query: miller
+    subauth: mprojection
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mprojection/de"
+  -
+    query: isbd
+    subauth: mpunctuation_conventions
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mpunctuationConventions/isbd"
+  -
+    query: optical
+    subauth: mrecmedium
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mrecmedium/opt"
+  -
+    query: analog
+    subauth: mrectype
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mrectype/analog"
+  -
+    query: high
+    subauth: mreductionratio
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mreductionratio/veryhigh"
+  -
+    query: region 8
+    subauth: mregencoding
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mregencoding/region8"
+  -
+    query: land
+    subauth: mrelief
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mrelief/land"
+  -
+    query: scale
+    subauth: mscale
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mscale/notdrawn"
+  -
+    query: chinese
+    subauth: mscript
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mscript/e"
+  -
+    query: silent
+    subauth: msoundcontent
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/msoundcontent/silent"
+  -
+    query: audio
+    subauth: mspecplayback
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mspecplayback/dtshd51"
+  -
+    query: invalid
+    subauth: mstatus
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mstatus/cancinv"
+  -
+    query: index
+    subauth: msupplcont
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/msupplcont/thematicindex"
+  -
+    query: braille
+    subauth: mtactile
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mtactile/math"
+  -
+    query: half
+    subauth: mtapeconfig
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mtapeconfig/half"
+  -
+    query: action
+    subauth: mtechnique
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mtechnique/animlive"
+  -
+    query: laser
+    subauth: mvidformat
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/mvidformat/laser"
+  -
+    query: actor
+    subauth: relators
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/relators/vac"
+  -
+    query: sound
+    subauth: resource_components
+    position: 4
+    subject_uri: "http://id.loc.gov/vocabulary/resourceComponents/str"

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
@@ -26,7 +26,6 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Malignant Hyperthermia
     subject_uri: "http://id.nlm.nih.gov/mesh/D008305"
     position: 3

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
@@ -25,13 +25,13 @@ search:
     subauth: topic
     replacements:
       maxRecords: '4'
-#  -
-#    query: War
-#    subauth: event_name
-#    replacements:
-#      maxRecords: '4'
   -
-    query: Festival
+    query: tribunal
+    subauth: event_name
+    replacements:
+      maxRecords: '4'
+  -
+    query: convention
     subauth: meeting
     replacements:
       maxRecords: '4'
@@ -71,7 +71,6 @@ search:
     replacements:
       maxRecords: '5'
   -
-    pending: true
     query: Sleep-overs
     subauth: concept
     subject_uri: "http://id.worldcat.org/fast/1120873"
@@ -86,6 +85,13 @@ search:
     position: 3
     replacements:
       maxRecords: '8'
+  -
+    query: Science Fiction
+    subauth: meeting
+    subject_uri: "http://id.worldcat.org/fast/1406163"
+    position: 5
+    replacements:
+      maxRecords: '10'
   -
     pending: true
     query: University of Chicago Library
@@ -102,7 +108,6 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: Sjælland
     subauth: place
     result_size: 190
@@ -111,13 +116,12 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Scream
     subauth: work
     subject_uri: "http://id.worldcat.org/fast/1358031"
-    position: 5
+    position: 10
     replacements:
-      maxRecords: '10'
+      maxRecords: '20'
 term:
   -
     identifier: '1914919'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -14,6 +14,9 @@ search:
     query: tribunal
     subauth: event
   -
+    query: convention
+    subauth: meeting
+  -
     query: 'mark twain'
     subauth: person
   -
@@ -52,6 +55,13 @@ search:
     replacements:
       maxRecords: '8'
   -
+    query: Science Fiction
+    subauth: meeting
+    subject_uri: "http://id.worldcat.org/fast/1406163"
+    position: 5
+    replacements:
+      maxRecords: '10'
+  -
     pending: true
     query: University of Chicago Library
     subauth: organization
@@ -75,19 +85,19 @@ search:
     replacements:
       maxRecords: '10'
   -
-    query: 'mark twain'
-    subauth: intangible
-    subject_uri: "http://id.worldcat.org/fast/1200561"
-    position: 3
-    replacements:
-      maxRecords: '10'
-  -
     query: Scream
     subauth: work
     subject_uri: "http://id.worldcat.org/fast/1358031"
     position: 10
     replacements:
       maxRecords: '20'
+  -
+    query: 'mark twain'
+    subauth: intangible
+    subject_uri: "http://id.worldcat.org/fast/1200561"
+    position: 3
+    replacements:
+      maxRecords: '10'
 term:
   -
     identifier: 'http://id.worldcat.org/fast/1914919'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -32,7 +32,6 @@ search:
   #  Accuracy tests
   #------------------
   -
-    pending: true
     query: Tralee & Dingle Railway
     subject_uri: "http://id.worldcat.org/fast/1733583"
     position: 3
@@ -53,6 +52,7 @@ search:
     replacements:
       maxRecords: '8'
   -
+    pending: true
     query: University of Chicago Library
     subauth: organization
     subject_uri: "http://id.worldcat.org/fast/539173"
@@ -75,13 +75,19 @@ search:
     replacements:
       maxRecords: '10'
   -
+    query: 'mark twain'
+    subauth: intangible
+    subject_uri: "http://id.worldcat.org/fast/1200561"
+    position: 3
+    replacements:
+      maxRecords: '10'
+  -
     query: Scream
     subauth: work
     subject_uri: "http://id.worldcat.org/fast/1358031"
     position: 10
     replacements:
       maxRecords: '20'
-
 term:
   -
     identifier: 'http://id.worldcat.org/fast/1914919'

--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/rda_registry_ld4l_cache_validation.yml
@@ -316,7 +316,6 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: polychrome
     subauth: colour_content
     position: 3
@@ -457,7 +456,6 @@ search:
     replacements:
       maxRecords: '20'
   -
-    pending: true
     query: unknown
     subauth: gender
     position: 3
@@ -556,7 +554,6 @@ search:
     replacements:
       maxRecords: '10'
   -
-    pending: true
     query: Hi 8
     subauth: video_format
     position: 3

--- a/spec/feature/accuracy_spec.rb
+++ b/spec/feature/accuracy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Accuracy test' do # rubocop:disable RSpec/DescribeClass
         it "finds actual <= expected" do
           pending 'test is known to fail' if test_result[:pending]
           expect(test_result[:err_message]).to be_empty
-          expect(test_result[:request_data]).not_to be_empty
+          expect(test_result[:request_data]).to be_present
           expect(test_result[:actual]).not_to be_nil
           expect(test_result[:actual]).to be <= test_result[:expected]
         end


### PR DESCRIPTION
Primarily removes `pending=true` from tests that are now passing.