### PR TITLE
do not directly include linkeddata and qa gems

### DIFF
--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'useragent'
 
   # Required gems for QA and linked data access
-  spec.add_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
-  spec.add_dependency 'linkeddata'
+  spec.add_development_dependency 'qa', '~> 5.5', '>= 5.5.1' # questioning_authority
+  spec.add_development_dependency 'linkeddata'
 
   # Produces dashboard charts on monitor status page
   spec.add_dependency 'gruff'


### PR DESCRIPTION
If these gems are dependencies instead of development_dependencies, OCLCFAST_DIRECT fails to get any data back as RDF.  Instead, it comes back as XML.  It is not clear why this happens and may not have happened outside of the .internal_test app.  But since it is not required for these to be direct dependencies, they were switched back to development_dependencies.