### PR TITLE
move Spain subject to accuracy tests

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
@@ -15,10 +15,6 @@ search:
     query: Malignant Hyperthermia
     subauth: subject
   -
-    query: Spain
-    subauth: subject
-    result_size: 75
-  -
     query: Address
     subauth: publication_type
     result_size: 80
@@ -43,6 +39,14 @@ search:
     query: Letter
     subauth: publication_type
     subject_uri: "http://id.nlm.nih.gov/mesh/D016422"
+    position: 3
+    replacements:
+      maxRecords: '8'
+  -
+    pending: true
+    query: Spain
+    subauth: subject
+    subject_uri: "http://id.nlm.nih.gov/mesh/D013030"
     position: 3
     replacements:
       maxRecords: '8'


### PR DESCRIPTION
Connection tests are meant to verify that the authority is up and accessible.  They do not have to fully test all aspects of the authority.  There is already a connection test for the subject subauth.  So the failure of Spain was moved to the accuracy tests.