### PR TITLE
release v7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 7.6.0 (2021-04-12)
+
+* update authority configs and test scenarios to use the new cache indexing with results stored as blobs in the index
+* update to Rails 5.2.5
+* update dependencies
+* fix exception when first time running monitor status
+
 ### 7.5.1 (2020-12-08)
 
 * define missing i18n translations

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '7.5.1'
+  VERSION = '7.6.0'
 end


### PR DESCRIPTION
* update authority configs and test scenarios to use the new cache indexing with results stored as blobs in the index
* update to Rails 5.2.5
* update dependencies
* fix exception when first time running monitor status
