### PR TITLE
dogear pending accuracy tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 7.8.0 (2021-04-14)
 
 * add geographic subauth for Mesh-NLM
+* dogear expected and actual cells when accuracy test is pending
 
 ### 7.7.1 (2021-04-14)
 

--- a/app/assets/stylesheets/qa_server/_check-status.scss
+++ b/app/assets/stylesheets/qa_server/_check-status.scss
@@ -88,6 +88,10 @@ td.bold-left-border {
   border-left: 2px solid black;
 }
 
+.status-dogear {
+  background: linear-gradient(135deg, #333 0%, #333 10%, transparent 10%, transparent 100%);
+}
+
 .status-good {
   text-align: center;
   background-color: #ccffcc;

--- a/app/presenters/qa_server/check_status_presenter.rb
+++ b/app/presenters/qa_server/check_status_presenter.rb
@@ -81,7 +81,7 @@ module QaServer
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
     def status_style_class(status)
-      "status-#{status}"
+      status[:pending] ? "status-dogear status-#{status[:status]}" : "status-#{status[:status]}"
     end
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.

--- a/app/views/qa_server/check_status/index.html.erb
+++ b/app/views/qa_server/check_status/index.html.erb
@@ -44,8 +44,6 @@
       <select name="authority" id="authority" class="string optional form-control form-control" value="" aria-labelledby="authority" onchange="hide_data()">
         <option value=""><%= t('qa_server.check_status.select_authority') %></option>
         <option disabled>──────────</option>
-        <option value="<%= @presenter.value_all_collections %>"><%= t('qa_server.check_status.show_all') %></option>
-        <option disabled>──────────</option>
         <% @authorities_list.each do |auth_name| %>
           <option value="<%= auth_name %>"<%= " selected" if auth_name == selected_authority %>><%= auth_name.upcase %></option>
         <% end %>
@@ -77,7 +75,10 @@
   <% end %>
 
 
-<div id="status-loading-message" class="wait-message"><%= t('qa_server.check_status.wait_message') %></div>
+<div id="status-loading-message" class="wait-message">
+  <%= t('qa_server.check_status.wait_message_ln1') %><br>
+  <%= t('qa_server.check_status.wait_message_ln2') %>
+</div>
 
 <% if @presenter.connection_status_data? %>
 <div id="connection-status-section" class="status-section">
@@ -100,7 +101,7 @@
           </tr>
       <% end %>
       <tr>
-        <td class="<%= @presenter.status_style_class(status[:status]) %>"><%= @presenter.status_label(status[:status]) %></td>
+        <td class="<%= @presenter.status_style_class(status) %>"><%= @presenter.status_label(status[:status]) %></td>
         <td><%= status[:subauthority_name] %></td>
         <td><%= status[:service] %></td>
         <td><%= status[:action] %></td>
@@ -137,8 +138,8 @@
         </tr>
       <% end %>
     <tr>
-      <td class="position <%= @presenter.status_style_class(status[:status]) %>"><%= status[:expected] %></td>
-      <td class="position <%= @presenter.status_style_class(status[:status]) %>"><%= status[:actual] %></td>
+      <td class="position <%= @presenter.status_style_class(status) %>"><%= status[:expected] %></td>
+      <td class="position <%= @presenter.status_style_class(status) %>"><%= status[:actual] %></td>
       <td><%= status[:request_data] %></td>
       <td><a href="<%= status[:target] %>"><%= status[:target] %></a></td>
       <td><%= status[:authority_name] %></td>

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -25,12 +25,12 @@ en:
     check_status:
       title:             Check Status
       select_authority:  Select authority...
-      show_all:          ALL Authorities (SLOW)
       connections:       Check Connection Status only
       accuracy:          Check Accuracy only
       comparison:        Compare Accuracy
       all_checks:        Run all checks
-      wait_message:      "Please wait while the status is verified.  This will be slow if you selected ALL Authorities."
+      wait_message_ln1:  "Please wait while the status is verified."
+      wait_message_ln2:  "This may be slow for large authorities or ones with a lot of tests."
       connection_checks: Connection Checks
       accuracy_checks:   Accuracy Checks for Search Results
       comparison_checks: Comparison of Accuracy Checks


### PR DESCRIPTION
Fixes #445

Changes:
* add css to dogear pending accuracy tests
* remove option to run all tests on check status page

This allows for quick identification through the UI whether a test is expected to fail.  It also allows for quick identification of a test that used to fail and now passes indicating the pending tag should be removed from the test.