### PR TITLE
fix compare accuracy and release 7.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.9.1 (2021-06-10)
+
+* fix compare accuracy fails if either has pending tests
+
 ### 7.9.0 (2021-04-16)
 
 * Add chart showing simulated graph (in table) of the last 30 days of up-down connection data

--- a/app/presenters/qa_server/check_status_presenter.rb
+++ b/app/presenters/qa_server/check_status_presenter.rb
@@ -81,6 +81,7 @@ module QaServer
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
     def status_style_class(status)
+      return "status-#{status}" if status.is_a? Symbol
       status[:pending] ? "status-dogear status-#{status[:status]}" : "status-#{status[:status]}"
     end
 

--- a/app/views/qa_server/check_status/index.html.erb
+++ b/app/views/qa_server/check_status/index.html.erb
@@ -151,6 +151,7 @@
     </tr>
     <% end %>
   </table>
+  <p><i>NOTE: Dogear means that the test is a known failure marked as pending.</i></p>
 </div>
 <% end %>
 

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '7.9.0'
+  VERSION = '7.9.1'
 end


### PR DESCRIPTION
Checking status when doing a comparison of two authorities receives a Symbol instead of the status hash.  The simple fix is to use use the passed in status Symbol and not worry about marking tests pending when doing a comparison.