### PR TITLE
Release 7.9.2 with FIX: only check for dogear if status is a Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 7.9.2 (2021-06-10)
+
+* fix: only check for dogear if status is a Hash
+
 ### 7.9.1 (2021-06-10)
 
 * fix compare accuracy fails if either has pending tests

--- a/app/presenters/qa_server/check_status_presenter.rb
+++ b/app/presenters/qa_server/check_status_presenter.rb
@@ -81,7 +81,7 @@ module QaServer
 
     # @return [String] the name of the css style class to use for the status cell based on the status of the scenario test.
     def status_style_class(status)
-      return "status-#{status}" if status.is_a? Symbol
+      return "status-#{status}" unless status.is_a? Hash
       status[:pending] ? "status-dogear status-#{status[:status]}" : "status-#{status[:status]}"
     end
 

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '7.9.1'
+  VERSION = '7.9.2'
 end


### PR DESCRIPTION
To avoid an exception, only check for pending tests and set the dogear style if status is a Hash.