### PR TITLE
Added test for Form subauth and renamed intangibles to topic

### DIFF
--- a/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/lib/generators/qa_server/templates/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -93,11 +93,19 @@ search:
       maxRecords: '20'
   -
     query: 'mark twain'
-    subauth: intangible
+    subauth: topic
     subject_uri: "http://id.worldcat.org/fast/1200561"
     position: 3
     replacements:
       maxRecords: '10'
+  -
+    query: 'Popup books'
+    subauth: form
+    subject_uri: "http://id.worldcat.org/fast/1919955"
+    position: 3
+    replacements:
+      maxRecords: '10'
+
 term:
   -
     identifier: 'http://id.worldcat.org/fast/1914919'


### PR DESCRIPTION
We currently lump topics and forms in one subauth (intangibles). When we split the two out, these changes will test those new subauths.