### PR TITLE
Update Rails dependency; bump to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 8.0.0 (2023-11-01)
+* Update Rails dependency to 7.0
+
 ### 7.9.2 (2021-06-10)
 
 * fix: only check for dogear if status is a Hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 8.0.0 (2023-11-01)
-* Update Rails dependency to 7.0
+* Update Rails dependency to 7.0 
 
 ### 7.9.2 (2021-06-10)
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This rails engine can be installed into your app to serve as a Questioning Autho
 
 Tested with...
 
-* Ruby 2.4.3
-* Rails 5.1.6
+* Ruby 3.1.2
+* Rails 7.0.8
 
 ### Optional Prerequisites
 

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '7.9.2'
+  VERSION = '8.0.0'
 end

--- a/qa_server.gemspec
+++ b/qa_server.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Note: rails does not follow sem-ver conventions, it's
   # minor version releases can include breaking changes; see
   # http://guides.rubyonrails.org/maintenance_policy.html
-  spec.add_dependency 'rails', '~> 5.2', '>= 5.2.5' # v5.2.5 required to address mimemagic gem yank
+  spec.add_dependency 'rails', '~> 7.0'
   spec.add_dependency 'useragent'
 
   # Required gems for QA and linked data access


### PR DESCRIPTION
See https://github.com/cul-it/qa_server/issues/386

In order to update Ruby and Rails in [qa_server_container](https://github.com/LD4P/qa_server_container), Rails must be updated to 7.0 here.