### PR TITLE
Release 8.0.1

### DIFF
--- a/app/prepends/prepended_rdf/rdf_graph.rb
+++ b/app/prepends/prepended_rdf/rdf_graph.rb
@@ -19,7 +19,8 @@ module PrependedRdf::RdfGraph
     performance_udpates = {}
     start_time_s = QaServer::TimeService.current_time_s
 
-    reader = RDF::Reader.open(real_url, { base_uri: real_url }.merge(options))
+    reader_options = { base_uri: real_url }.merge(options)
+    reader = RDF::Reader.open(real_url, **reader_options)
 
     end_time_s = QaServer::TimeService.current_time_s
     performance_udpates[:retrieve_time_ms] = (end_time_s - start_time_s) * 1000

--- a/lib/qa_server/version.rb
+++ b/lib/qa_server/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module QaServer
-  VERSION = '8.0.0'
+  VERSION = '8.0.1'
 end


### PR DESCRIPTION
- Fixes rdf reader ArgumentError due to ruby 3 changes in handling positional and keyword arguments: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/